### PR TITLE
version change only with empty pkgs arg in install

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BiocManager
 Title: Access the Bioconductor Project Package Repository
 Description: A convenient tool to install and update Bioconductor packages.
-Version: 1.30.1
+Version: 1.30.2
 Authors@R: c(
     person("Martin", "Morgan", email = "martin.morgan@roswellpark.org",
         role = "aut", comment = c(ORCID = "0000-0002-5874-8148")),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+CHANGES IN VERSION 1.31.2
+-------------------------
+
+USER VISIBLE CHANGES
+
+    o install() only allows Bioconductor version upgrades and downgrades with
+    an empty 'pkgs' argument. Otherwise, it gives the user an informative error.
+
 CHANGES IN VERSION 1.31.0
 -------------------------
 
@@ -26,6 +34,7 @@ NEW FEATURES
 
     o available() enables package discovery via grep()
 
+    o Removed support for MRAN (Microsoft R) archives.
 
 CHANGES IN VERSION 1.28.0
 -------------------------

--- a/R/install.R
+++ b/R/install.R
@@ -130,11 +130,18 @@
     TRUE
 }
 
+.resolve_npkgs <- function(installed, repos, type = getOption("pkgType")) {
+    contribUrl <- contrib.url(repos, type=type)
+
+    availPkgs <- available.packages(contribUrl, type=type)
+    sum(rownames(installed) %in% availPkgs)
+}
+
 .install_ask_up_or_down_grade <-
-    function(version, cmp)
+    function(version, npkgs, cmp, action)
 {
-    action <- if (cmp < 0) "Downgrade" else "Upgrade"
-    txt <- sprintf("%s Bioconductor to version '%s'? [y/n]: ", action, version)
+    txt <- sprintf("%s %i packages to Bioconductor version '%s'? [y/n]: ",
+        action, npkgs, version)
     .getAnswer(txt, allowed = c("y", "Y", "n", "N")) == "y"
 }
 
@@ -324,15 +331,28 @@ install <-
     )
     version <- .version_validate(version)
 
-    if (!"BiocVersion" %in% rownames(installed.packages())) {
+    inst <- installed.packages()
+    if (!"BiocVersion" %in% rownames(inst)) {
         pkgs <- unique(c("BiocVersion", pkgs))
     }
 
     cmp <- .version_compare(version, version())
+    action <- if (cmp < 0) "Downgrade" else "Upgrade"
+    repos <- repositories(site_repository, version = version)
+
     if (cmp != 0L) {
-        .install_ask_up_or_down_grade(version, cmp) ||
-            .stop("Bioconductor version not changed")
-        pkgs <- unique(c("BiocVersion", pkgs))
+        npkgs <- .resolve_npkgs(inst, repos)
+        if (!length(pkgs)) {
+            .install_ask_up_or_down_grade(version, npkgs, cmp, action) ||
+                .stop("Bioconductor version not changed")
+            pkgs <- unique(c("BiocVersion", pkgs))
+        } else
+            stop(
+                "To use Bioconductor version '", version, "', ",
+                tolower(action), " ", npkgs, " packages with\n",
+                "    \"BiocManager::install(version = '", version, "')\"",
+                call. = FALSE
+            )
     }
 
     .message(
@@ -341,7 +361,6 @@ install <-
         sub(" version", "", R.version.string)
     )
 
-    repos <- repositories(site_repository, version = version)
     pkgs <- .install(pkgs, repos = repos, ...)
     if (update && cmp == 0L) {
         .install_update(repos, ask, ...)


### PR DESCRIPTION
These are the changes as discussed:

@mtmorgan:
```
> BiocManager::install(version="3.8")
Upgrade Bioconductor to version '3.8'? [y/n]:
``` 
becomes
```
> BiocManager::install(version="3.8")
Update 123 packages to Bioconductor version '3.8'? [y/n]:
``` 
and
```
> BiocManager::install("foo", version="3.8")
```
says something like

`To use Bioconductor version '3.8', upgrade 123 packages with "BiocManager::install(version = "3.8")`