### PR TITLE
warn instead of error on unknown version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BiocManager
 Title: Access the Bioconductor Project Package Repository
 Description: A convenient tool to install and update Bioconductor packages.
-Version: 1.30.3
+Version: 1.30.4
 Authors@R: c(
     person("Martin", "Morgan", email = "martin.morgan@roswellpark.org",
         role = "aut", comment = c(ORCID = "0000-0002-5874-8148")),

--- a/R/version.R
+++ b/R/version.R
@@ -173,7 +173,7 @@
     version <- .package_version(version)
 
     txt <- .version_validity(version)
-    isTRUE(txt) || .warning(txt)
+    isTRUE(txt) || .stop(txt)
 
     version
 }

--- a/R/version.R
+++ b/R/version.R
@@ -173,7 +173,7 @@
     version <- .package_version(version)
 
     txt <- .version_validity(version)
-    isTRUE(txt) || .stop(txt)
+    isTRUE(txt) || .warning(txt)
 
     version
 }

--- a/R/version.R
+++ b/R/version.R
@@ -156,7 +156,7 @@
 
     r_version <- getRversion()[, 1:2]
     status <- map$BiocStatus[map$Bioc == version & map$R == r_version]
-    if (status == "future")
+    if (identical(status, "future"))
         return(sprintf(
             "Bioconductor does not yet formally support R version '%s'",
             r_version

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -11,11 +11,7 @@
     }
 
     valid <- .version_validity(version)
-    if (identical(valid, .VERSION_MAP_UNABLE_TO_VALIDATE)) {
-        .warning(valid)
-        return()
-    }
-    isTRUE(valid) || .stop(valid)
+    isTRUE(valid) || .warning(valid)
 
     fmt <- paste0(
         "Bioconductor version %s (BiocManager %s), ",


### PR DESCRIPTION
- e.g., at release, when 'r_ver_for_bioc_ver' is not present in
  web site config.yaml