### PR TITLE
Speedup of BiocManager::version() when there are a large number of installed packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BiocManager
 Title: Access the Bioconductor Project Package Repository
 Description: A convenient tool to install and update Bioconductor packages.
-Version: 1.30.4.9005
+Version: 1.30.4.9006
 Authors@R: c(
     person("Martin", "Morgan", email = "martin.morgan@roswellpark.org",
         role = "aut", comment = c(ORCID = "0000-0002-5874-8148")),

--- a/R/version.R
+++ b/R/version.R
@@ -102,11 +102,10 @@
 .version_map_get_offline <-
     function()
 {
-    if ("BiocVersion" %in% rownames(installed.packages())) {
-        bioc <- packageVersion("BiocVersion")[, 1:2]
-        .warning(.NO_ONLINE_VERSION_DIAGNOSIS)
-    } else
-        return(.VERSION_MAP_SENTINEL)
+    bioc <- tryCatch(packageVersion("BiocVersion")[, 1:2], error = identity)
+    if (inherits(bioc, "error")) return(.VERSION_MAP_SENTINEL)
+    .warning(.NO_ONLINE_VERSION_DIAGNOSIS)
+    
     r <- package_version(R.Version())[,1:2]
 
     status <- c("out-of-date", "release", "devel", "future")
@@ -279,10 +278,11 @@
 .local_version <-
     function()
 {
-    if ("BiocVersion" %in% rownames(installed.packages()))
+    tryCatch({
         packageVersion("BiocVersion")[, 1:2]
-    else
+    }, error = function(e) {
         .VERSION_SENTINEL
+    })
 }
 
 #' Version of Bioconductor currently in use.
@@ -307,10 +307,11 @@
 version <-
     function()
 {
-    if ("BiocVersion" %in% rownames(installed.packages()))
+    tryCatch({
         packageVersion("BiocVersion")[, 1:2]
-    else
+    }, error = function(e) {
         .version_choose_best()
+    })	
 }
 
 .package_version <-


### PR DESCRIPTION
This is a patch that avoids calling `installed.packages()` to conditionally get the version of the BiocVersion package.

# BiocManager 1.30.4

```r
$ R --quiet --vanilla
> system.time(BiocManager::version())
   user  system elapsed 
   0.652   0.611   4.248
```
because
```r
> system.time(db <- installed.packages())
   user  system elapsed 
  0.646   0.601   4.257 
> nrow(db)
[1] 999
```

# BiocManager 1.30.4.9005

```r
$ R --quiet --vanilla
> system.time(BiocManager::version())
Bioconductor version 3.8 (BiocManager 1.30.4.9005), ?BiocManager::install for
  help
   user  system elapsed 
  0.820   0.614   4.393
```


# BiocManager 1.30.4.9006

```r
$ R --quiet --vanilla
> system.time(BiocManager::version())
Bioconductor version 3.8 (BiocManager 1.30.4.9006), ?BiocManager::install for
  help
   user  system elapsed 
  0.115   0.089   0.327
```
