### PR TITLE
Slightly more precise error message

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -72,7 +72,7 @@
             "%s\n    %s\n%s",
             "package 'remotes' not installed in library path(s)",
             paste(lib.loc, collapse="\n    "),
-            "install with 'install(\"remotes\")'",
+            "install with 'BiocManager::install(\"remotes\")'",
             call. = FALSE,
             wrap. = FALSE
         )


### PR DESCRIPTION
Minor: If someone ran `BiocManager::install()` (without first running `library(BiocManager)`) and hit this error, then copy+pasting the suggested remedy won't work whereas the modified one will.