### PR TITLE
Support using a custom config.yaml file from BioC mirror

### DIFF
--- a/R/version.R
+++ b/R/version.R
@@ -174,8 +174,13 @@ format.version_sentinel <-
     if (!.version_validity_online_check())
         .version_map_get_offline()
     else {
-        if (is.null(config))
-            config <- "https://bioconductor.org/config.yaml"
+        if (is.null(config)) {
+            mirror <- getOption("BioC_mirror", "https://bioconductor.org")
+            config <- file.path(mirror, "config.yaml")
+            if (!tryCatch(.url_exists(config), warning = function(w) FALSE)) {
+                config <- "https://bioconductor.org/config.yaml"
+            }
+        }
         .version_map_get_online(config)
     }
 }

--- a/tests/testthat/bioc-mirror/config.yaml
+++ b/tests/testthat/bioc-mirror/config.yaml
@@ -1,0 +1,39 @@
+---
+## CHANGE THIS WHEN WE RELEASE A VERSION:
+release_version: "3.11"
+r_version_associated_with_release: "4.0.0"
+r_version_associated_with_devel: "4.0.0"
+
+## CHANGE THIS WHEN WE RELEASE A VERSION:
+devel_version: "3.12"
+
+# CHANGE THIS when it becomes apparent which future versions of BioC will
+# work with which versions of R:
+r_ver_for_bioc_ver:
+  "3.0": "3.1"
+  "3.1": "3.2"
+  "3.2": "3.2"
+  "3.3": "3.3"
+  "3.4": "3.3"
+  "3.5": "3.4"
+  "3.6": "3.4"
+  "3.7": "3.5"
+  "3.8": "3.5"
+  "3.9": "3.6"
+  "3.10": "3.6"
+  "3.11": "4.0"
+  "3.12": "4.0"
+# UPDATE THIS when we release a version
+release_dates:
+  "3.0": "10/14/2014"
+  "3.1": "4/17/2015"
+  "3.2": "10/14/2015"
+  "3.3": "5/4/2016"
+  "3.4": "10/18/2016"
+  "3.5": "4/25/2017"
+  "3.6": "10/31/2017"
+  "3.7": "05/01/2018"
+  "3.8": "10/31/2018"
+  "3.9": "05/03/2019"
+  "3.10": "10/30/2019"
+  "3.11": "04/28/2020"

--- a/tests/testthat/test_version.R
+++ b/tests/testthat/test_version.R
@@ -186,6 +186,27 @@ test_that(".version_map_get() falls back to http", {
     expect_identical(result, .VERSION_MAP_SENTINEL)
 })
 
+test_that(".version_map_get() works with default mirror", {
+    skip_if_offline()
+    map <- .version_map_get_online("https://bioconductor.org/config.yaml")
+    expect_identical(.version_map_get(), map)
+})
+
+test_that(".version_map_get() works with custom mirror", {
+    map <- .version_map_get_online("bioc-mirror/config.yaml")
+    withr::with_options(list(BioC_mirror = "bioc-mirror"), {
+        expect_identical(.version_map_get(), map)
+    })
+})
+
+test_that(".version_map_get() falls back to default mirror", {
+    skip_if_offline()
+    map <- .version_map_get_online("https://bioconductor.org/config.yaml")
+    withr::with_options(list(BioC_mirror = "bioc-mirror-does-not-exist"), {
+        expect_identical(.version_map_get(), map)
+    })
+})
+
 test_that("BiocVersion version matches with .version_map()", {
     .skip_if_misconfigured()
     skip_if_offline()


### PR DESCRIPTION
Here's one idea to support using Bioconductor in a totally offline environment (https://github.com/Bioconductor/BiocManager/issues/75). Retrieve `config.yaml` from the configured BioC mirror if it exists; otherwise fall back to https://bioconductor.org/config.yaml.

To use this with a custom BioC mirror, you would add `config.yaml` to mirror, then set the `BioC_mirror` option as usual:
```r
options(BioC_mirror = "https://my-bioc-mirror.org")

options(BioC_mirror = "file:///path/to/bioc-mirror")
```

Then BiocManager would look up `https://my-bioc-mirror.org/config.yaml` or `file:///path/to/bioc-mirror/config.yaml` rather than https://bioconductor.org/config.yaml.


