### PR TITLE
CLEANUP: cran.rstudio.com -> cloud.r-project.org

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BiocManager
 Title: Access the Bioconductor Project Package Repository
 Description: A convenient tool to install and update Bioconductor packages.
-Version: 1.30.12.2
+Version: 1.30.12.3
 Authors@R: c(
     person("Martin", "Morgan", email = "martin.morgan@roswellpark.org",
         role = "aut", comment = c(ORCID = "0000-0002-5874-8148")),

--- a/R/repositories.R
+++ b/R/repositories.R
@@ -76,7 +76,7 @@
                 "'getOption(\"BiocManager.snapshot\")' must be one of %s",
                 paste0("'", valid, "'", collapse = " ")
             )
-        cran <- "https://cran.rstudio.com"
+        cran <- "https://cloud.r-project.org"
         repos[rename] <- switch(
             opt,
             RSPM = .repositories_rspm(cran),

--- a/tests/testthat/test_repositories.R
+++ b/tests/testthat/test_repositories.R
@@ -51,7 +51,7 @@ test_that("repositories(version = 'devel') works", {
 
 test_that("repositories helper replaces correct URL", {
     .skip_if_misconfigured()
-    default_repos <- c(CRAN = "https://cran.rstudio.com")
+    default_repos <- c(CRAN = "https://cloud.r-project.org")
 
     ## https://github.com/Bioconductor/BiocManager/issues/17
     repos <- "http://cran.cnr.Berkeley.edu"

--- a/vignettes/BiocManager.Rmd
+++ b/vignettes/BiocManager.Rmd
@@ -244,7 +244,7 @@ Set the environment variable `R_LIBS_USER` to this directory, and invoke _R_.
 Command line examples for Linux are
 
 - Linux: `R_LIBS_USER=~/R/3.5-Bioc-3.7 R`
-- macOS: `R_LIBS_USER=~~/Library/R/3.5-Bioc-3.7/library R`
+- macOS: `R_LIBS_USER=~/Library/R/3.5-Bioc-3.7/library R`
 - Windows: `cmd /C "set R_LIBS_USER=C:\Users\USER_NAME\Documents\R\3.5-Bioc-3.7 && R"`
 
 Once in _R_, confirm that the version-specific library path has been set

--- a/vignettes/BiocManager.Rmd
+++ b/vignettes/BiocManager.Rmd
@@ -95,8 +95,8 @@ Warning message:
 bit "bit"   "/home/mtmorgan/R/x86_64-pc-linux-gnu-library/3.5-Bioc-3.8"
 ff  "ff"    "/home/mtmorgan/R/x86_64-pc-linux-gnu-library/3.5-Bioc-3.8"
     Installed Built   ReposVer Repository
-bit "1.1-12"  "3.5.0" "1.1-13" "https://cran.rstudio.com/src/contrib"
-ff  "2.2-13"  "3.5.0" "2.2-14" "https://cran.rstudio.com/src/contrib"
+bit "1.1-12"  "3.5.0" "1.1-13" "https://cloud.r-project.org/src/contrib"
+ff  "2.2-13"  "3.5.0" "2.2-14" "https://cloud.r-project.org/src/contrib"
 >
 ```
 

--- a/vignettes/BiocManager.Rmd
+++ b/vignettes/BiocManager.Rmd
@@ -406,7 +406,7 @@ with more than one BiocVersion package installed. This might occur for
 instance if a 'system administrator' installed BiocVersion, and then a
 user installed their own version. In this circumstance, it seems
 appropriate to standardize the installation by repeatedly calling
-`remove.pacakges("BiocVersion")` until all versions are removed, and
+`remove.packages("BiocVersion")` until all versions are removed, and
 then installing the desired version.
 
 # `sessionInfo()`


### PR DESCRIPTION
I'm quite certain that `cloud.r-project.org` is a CRAN mirror sponsored by RStudio just like `cran.rstudio.com`.  Looking at `dig` or `nslookup`, both go to the same servers.  I don't know if the latter is deprecated, but it not part of the "known" URLs that R knows about;

```r
> mirrors <- utils:::getCRANmirrors()
> grep("rstudio", mirrors$URL)
integer(0)
> grep("cloud.r-project.org", mirrors$URL)
[1] 1
```

So, I recommend switching to `cloud.r-project.org` instead. This PR fixes that.
