### PR TITLE
Fixes for rmarkdown syntax errors in roxygen documentation code

### DIFF
--- a/R/BiocManager-pkg.R
+++ b/R/BiocManager-pkg.R
@@ -13,25 +13,25 @@ NULL
 #' Main functions are as follows; additional help is available for
 #' each function, e.g., `?BiocManager::version`.
 #'
-#' - `BiocManager::install()`: Install or update packages from
+#' - [`BiocManager::install()`]: Install or update packages from
 #'   _Bioconductor_, CRAN, and GitHub.
 #'
-#' - `BiocManager::version()`: Report the version of _Bioconductor_ in
+#' - [`BiocManager::version()`]: Report the version of _Bioconductor_ in
 #'     use.
 #'
-#' - `BiocManager::available()`: Return a `character()` vector of
-#'   package names available (at `BiocManager::repositories()`) for
+#' - [`BiocManager::available()`]: Return a `character()` vector of
+#'   package names available (at [`BiocManager::repositories()`]) for
 #'   installation.
 #'
-#' - `BiocManager::valid()`: Determine whether installed packages are
+#' - [`BiocManager::valid()`]: Determine whether installed packages are
 #'     from the same version of _Bioconductor_.
 #'
-#' - `BiocManager::repositories()`: _Bioconductor_ and other
+#' - [`BiocManager::repositories()`]: _Bioconductor_ and other
 #'    repository URLs to discover packages for installation.
 #'
 #' The version of _Bioconductor_ in use is determined by the installed
 #' version of a second package, BiocVersion. BiocVersion is installed
-#' automatically during first use of `BiocManager::install()`. If
+#' automatically during first use of [`BiocManager::install()`]. If
 #' BiocVersion has not yet been installed, the version is determined
 #' by code in base R.
 #'
@@ -40,10 +40,10 @@ NULL
 #'
 #' - `"repos"`, `"BiocManager.check_repositories"`,
 #'   `"BiocManager.snapshot"`: URLs of additional repositories for use
-#'   by `BiocManger::install()`. See `?repositories`.
+#'   by [`BiocManager::install()`]. See `?repositories`.
 #'
 #' - `"pkgType"`: The default type of packages to be downloaded and
-#'   installed; see `?install.packages`.
+#'   installed; see [`install.packages`].
 #'
 #' - `"timeout"`: The maximum time allowed for download of a single
 #'   package, in seconds. _BiocManager_ increases this to 300 seconds

--- a/R/install.R
+++ b/R/install.R
@@ -274,16 +274,16 @@
 #' Installation of _Bioconductor_ and CRAN packages use R's standard
 #' functions for library management -- `install.packages()`,
 #' `available.packages()`, `update.packages()`. Installation of GitHub
-#' packages uses the `remotes::install_github()`.
+#' packages uses the [`remotes::install_github()`].
 #'
 #' When installing CRAN or _Bioconductor_ packages, typical arguments
-#' include: `lib.loc`, passed to `\link{old.packages}()` and used to
+#' include: `lib.loc`, passed to [`old.packages()`] and used to
 #' determine the library location of installed packages to be updated;
-#' and `lib`, passed to `\link{install.packages}()` to determine the
+#' and `lib`, passed to [`install.packages()`] to determine the
 #' library location where `pkgs` are to be installed.
 #'
 #' When installing GitHub packages, `...` is passed to the
-#' \pkg{remotes} package functions `\link[remotes]{install_github}()`
+#' \pkg{remotes} package functions [`remotes::install_github()`]
 #' and `remotes:::install()`. A typical use is to build vignettes, via
 #' `dependencies=TRUE, build_vignettes=TRUE`.
 #'
@@ -306,13 +306,13 @@
 #'     update.  A missing value updates installed packages according
 #'     to `update =` and `ask =`. Package names containing a '/' are
 #'     treated as GitHub repositories and installed using
-#'     `remotes::install_github()`.
-#' @param ... Additional arguments used by `install.packages()`.
+#'     [`remotes::install_github()`].
+#' @param ... Additional arguments used by [`install.packages()`].
 #' @param site_repository (Optional) `character(1)` vector
 #'     representing an additional repository in which to look for
 #'     packages to install. This repository will be prepended to the
 #'     default repositories (which you can see with
-#'     `BiocManager::\link{repositories}()`).
+#'     [`BiocManager::repositories()`]).
 #' @param update `logical(1)`. When `FALSE`, `BiocManager::install()`
 #'     does not attempt to update old packages. When `TRUE`, update
 #'     old packages according to `ask`.
@@ -334,19 +334,19 @@
 #' @return `BiocManager::install()` returns the `pkgs` argument, invisibly.
 #' @seealso
 #'
-#' `BiocManager::\link{repositories}()` returns the _Bioconductor_ and
+#' [`BiocManager::repositories()`] returns the _Bioconductor_ and
 #' CRAN repositories used by `install()`.
 #'
-#' `\link{install.packages}()` installs the packages themselves (used by
+#' [`install.packages()`] installs the packages themselves (used by
 #' `BiocManager::install` internally).
 #'
-#' `\link{update.packages}()` updates all installed packages (used by
+#' [`update.packages()`] updates all installed packages (used by
 #' `BiocManager::install` internally).
 #'
-#' `\link{chooseBioCmirror}()` allows choice of a mirror from all
+#' [`chooseBioCmirror()`] allows choice of a mirror from all
 #' public _Bioconductor_ mirrors.
 #'
-#' `\link{chooseCRANmirror}()` allows choice of a mirror from all
+#' [`chooseCRANmirror()`] allows choice of a mirror from all
 #' public CRAN mirrors.
 #'
 #' @keywords environment

--- a/R/install.R
+++ b/R/install.R
@@ -287,7 +287,7 @@
 #' and `remotes:::install()`. A typical use is to build vignettes, via
 #' `dependencies=TRUE, build_vignettes=TRUE`.
 #'
-#' See `?repositories` for additional detail on customizing where
+#' See [`repositories`] for additional detail on customizing where
 #' BiocManager searches for package installation.
 #'
 #' \env{BIOCONDUCTOR_ONLINE_VERSION_DIAGNOSIS} is an environment

--- a/R/repositories.R
+++ b/R/repositories.R
@@ -136,7 +136,7 @@
 #'
 #' @description `repositories()` reports the URLs from which to
 #'     install _Bioconductor_ and CRAN packages. It is used by
-#'     `BiocManager::install()` and other functions.
+#'     [`BiocManager::install()`] and other functions.
 #'
 #' @param site_repository (Optional) `character(1)` representing an
 #'     additional repository (e.g., a URL to an organization's
@@ -210,16 +210,16 @@
 #'
 #' @seealso
 #'
-#' `BiocManager::\link{install}()` Installs or updates Bioconductor,
+#' [`BiocManager::install()`] Installs or updates Bioconductor,
 #'  CRAN, and GitHub packages.
 #'
-#' `\link{chooseBioCmirror}()` choose an alternative Bioconductor
+#' [`chooseBioCmirror()`] choose an alternative Bioconductor
 #' mirror; not usually necessary.
 #'
-#' `\link{chooseCRANmirror}()` choose an alternative CRAN mirror; not
+#' [`chooseCRANmirror()`] choose an alternative CRAN mirror; not
 #' usually necessary.
 #'
-#' `\link{setRepositories}()` Select additional repositories for
+#' [`setRepositories()`] Select additional repositories for
 #' searching.
 #'
 #' @keywords environment

--- a/R/valid.R
+++ b/R/valid.R
@@ -56,21 +56,21 @@
 #' nor too new) with the version of R and _Bioconductor_ in use.
 #'
 #' @details This function compares the version of installed packages
-#'     to the version of packages associated with the version of _R_
+#'     to the version of packages associated with the version of _R_ 
 #'     and _Bioconductor_ currently in use.
 #'
-#'     Packages are reported as 'out-of-date' if a more recent version
-#'     is available at the repositories specified by
-#'     `BiocManager::repositories()`.  Usually, `BiocManager::install()` is
-#'     sufficient to update packages to their most recent version.
+#' Packages are reported as 'out-of-date' if a more recent version
+#' is available at the repositories specified by
+#' [`BiocManager::repositories()`].  Usually, [`BiocManager::install()`] is
+#' sufficient to update packages to their most recent version.
 #'
-#'     Packages are reported as 'too new' if the installed version is
-#'     more recent than the most recent available in the
-#'     `BiocManager::repositories()`. It is possible to down-grade by
-#'     re-installing a too new package "PkgA" with
-#'     `BiocManger::install("PkgA")`. It is important for the user to
-#'     understand how their installation became too new, and to avoid
-#'     this in the future.
+#' Packages are reported as 'too new' if the installed version is
+#' more recent than the most recent available in the
+#' [`BiocManager::repositories()`]. It is possible to down-grade by
+#' re-installing a too new package "PkgA" with
+#' `BiocManger::install("PkgA")`. It is important for the user to
+#' understand how their installation became too new, and to avoid
+#' this in the future.
 #'
 #' @param pkgs A character() vector of package names for checking, or
 #'     a matrix as returned by `\link{installed.packages}`.

--- a/R/valid.R
+++ b/R/valid.R
@@ -73,22 +73,22 @@
 #' this in the future.
 #'
 #' @param pkgs A character() vector of package names for checking, or
-#'     a matrix as returned by `\link{installed.packages}`.
+#' a matrix as returned by [`installed.packages`].
 #' @param lib.loc A character() vector of library location(s) of
-#'     packages to be validated; see `\link{installed.packages}()`.
+#'     packages to be validated; see [`installed.packages()`].
 #' @param priority character(1) Check validity of all, "base", or
-#'     "recommended" packages; see `\link{installed.packages}()`.
+#'     "recommended" packages; see [`installed.packages()`].
 #' @param type character(1) The type of available package (e.g.,
 #'     binary, source) to check validity against; see
-#'     `\link{available.packages}()`.
+#'     [`available.packages()`].
 #' @param filters character(1) Filter available packages to check
-#'     validity against; see `\link{available.packages}()`.
+#'     validity against; see [`available.packages()`].
 #' @param \dots Additional arguments, passed to
-#'     `BiocManager::\link{install}()` when `fix=TRUE`.
+#'     [`BiocManager::install()`] when `fix=TRUE`.
 #' @param checkBuilt `logical(1)`. If `TRUE` a package built under an
 #'     earlier major.minor version of R (e.g., 3.4) is considered to
 #'     be old.
-#' @param site_repository `character(1)`. See `?install`.
+#' @param site_repository `character(1)`. See [`install`].
 #' @return `biocValid` list object with elements `too_new` and
 #'     `out_of_date` containing `data.frame`s with packages and their
 #'     installed locations that are too new or out-of-date for the
@@ -96,7 +96,7 @@
 #'     is unavailable, an empty 'biocValid' list is returned. If all
 #'     packages ('pkgs') are up to date, then TRUE is returned.
 #' @author Martin Morgan \email{martin.morgan@@roswellpark.org}
-#' @seealso `BiocManager::\link{install}()` to update installed
+#' @seealso [`BiocManager::install()`] to update installed
 #'     packages.
 #' @keywords environment
 #' @examples

--- a/R/valid.R
+++ b/R/valid.R
@@ -151,6 +151,7 @@ valid <-
 #' @rdname valid
 #' @param x A `biocValid` object returned by `BiocManager::valid()`.
 #' @return `print()` is invoked for its side effect.
+#' @md
 #' @export
 print.biocValid <-
     function(x, ...)

--- a/man/BiocManager-pkg.Rd
+++ b/man/BiocManager-pkg.Rd
@@ -15,22 +15,22 @@ versioning and release system.
 Main functions are as follows; additional help is available for
 each function, e.g., \code{?BiocManager::version}.
 \itemize{
-\item \code{BiocManager::install()}: Install or update packages from
+\item \code{\link[=install]{install()}}: Install or update packages from
 \emph{Bioconductor}, CRAN, and GitHub.
-\item \code{BiocManager::version()}: Report the version of \emph{Bioconductor} in
+\item \code{\link[=version]{version()}}: Report the version of \emph{Bioconductor} in
 use.
-\item \code{BiocManager::available()}: Return a \code{character()} vector of
-package names available (at \code{BiocManager::repositories()}) for
+\item \code{\link[=available]{available()}}: Return a \code{character()} vector of
+package names available (at \code{\link[=repositories]{repositories()}}) for
 installation.
-\item \code{BiocManager::valid()}: Determine whether installed packages are
+\item \code{\link[=valid]{valid()}}: Determine whether installed packages are
 from the same version of \emph{Bioconductor}.
-\item \code{BiocManager::repositories()}: \emph{Bioconductor} and other
+\item \code{\link[=repositories]{repositories()}}: \emph{Bioconductor} and other
 repository URLs to discover packages for installation.
 }
 
 The version of \emph{Bioconductor} in use is determined by the installed
 version of a second package, BiocVersion. BiocVersion is installed
-automatically during first use of \code{BiocManager::install()}. If
+automatically during first use of \code{\link[=install]{install()}}. If
 BiocVersion has not yet been installed, the version is determined
 by code in base R.
 
@@ -39,9 +39,9 @@ include:
 \itemize{
 \item \code{"repos"}, \code{"BiocManager.check_repositories"},
 \code{"BiocManager.snapshot"}: URLs of additional repositories for use
-by \code{BiocManger::install()}. See \code{?repositories}.
+by \code{\link[=install]{install()}}. See \code{?repositories}.
 \item \code{"pkgType"}: The default type of packages to be downloaded and
-installed; see \code{?install.packages}.
+installed; see \code{\link{install.packages}}.
 \item \code{"timeout"}: The maximum time allowed for download of a single
 package, in seconds. \emph{BiocManager} increases this to 300 seconds
 to accommodate download of large BSgenome and other packages.

--- a/man/install.Rd
+++ b/man/install.Rd
@@ -21,15 +21,15 @@ install(
 update.  A missing value updates installed packages according
 to \verb{update =} and \verb{ask =}. Package names containing a '/' are
 treated as GitHub repositories and installed using
-\code{remotes::install_github()}.}
+\code{\link[remotes:install_github]{remotes::install_github()}}.}
 
-\item{...}{Additional arguments used by \code{install.packages()}.}
+\item{...}{Additional arguments used by \code{\link[=install.packages]{install.packages()}}.}
 
 \item{site_repository}{(Optional) \code{character(1)} vector
 representing an additional repository in which to look for
 packages to install. This repository will be prepended to the
 default repositories (which you can see with
-\verb{BiocManager::\link{repositories}()}).}
+\code{\link[=repositories]{repositories()}}).}
 
 \item{update}{\code{logical(1)}. When \code{FALSE}, \code{BiocManager::install()}
 does not attempt to update old packages. When \code{TRUE}, update
@@ -66,20 +66,20 @@ additional steps; see \url{https://bioconductor.org/install}.
 Installation of \emph{Bioconductor} and CRAN packages use R's standard
 functions for library management -- \code{install.packages()},
 \code{available.packages()}, \code{update.packages()}. Installation of GitHub
-packages uses the \code{remotes::install_github()}.
+packages uses the \code{\link[remotes:install_github]{remotes::install_github()}}.
 
 When installing CRAN or \emph{Bioconductor} packages, typical arguments
-include: \code{lib.loc}, passed to \verb{\link{old.packages}()} and used to
+include: \code{lib.loc}, passed to \code{\link[=old.packages]{old.packages()}} and used to
 determine the library location of installed packages to be updated;
-and \code{lib}, passed to \verb{\link{install.packages}()} to determine the
+and \code{lib}, passed to \code{\link[=install.packages]{install.packages()}} to determine the
 library location where \code{pkgs} are to be installed.
 
 When installing GitHub packages, \code{...} is passed to the
-\pkg{remotes} package functions \verb{\link[remotes]\{install_github\}()}
+\pkg{remotes} package functions \code{\link[remotes:install_github]{remotes::install_github()}}
 and \code{remotes:::install()}. A typical use is to build vignettes, via
 \verb{dependencies=TRUE, build_vignettes=TRUE}.
 
-See \code{?repositories} for additional detail on customizing where
+See \code{\link{repositories}} for additional detail on customizing where
 BiocManager searches for package installation.
 
 \env{BIOCONDUCTOR_ONLINE_VERSION_DIAGNOSIS} is an environment
@@ -113,19 +113,19 @@ BiocManager::install("IRanges", type="source")
 
 }
 \seealso{
-\verb{BiocManager::\link{repositories}()} returns the \emph{Bioconductor} and
+\code{\link[=repositories]{repositories()}} returns the \emph{Bioconductor} and
 CRAN repositories used by \code{install()}.
 
-\verb{\link{install.packages}()} installs the packages themselves (used by
+\code{\link[=install.packages]{install.packages()}} installs the packages themselves (used by
 \code{BiocManager::install} internally).
 
-\verb{\link{update.packages}()} updates all installed packages (used by
+\code{\link[=update.packages]{update.packages()}} updates all installed packages (used by
 \code{BiocManager::install} internally).
 
-\verb{\link{chooseBioCmirror}()} allows choice of a mirror from all
+\code{\link[=chooseBioCmirror]{chooseBioCmirror()}} allows choice of a mirror from all
 public \emph{Bioconductor} mirrors.
 
-\verb{\link{chooseCRANmirror}()} allows choice of a mirror from all
+\code{\link[=chooseCRANmirror]{chooseCRANmirror()}} allows choice of a mirror from all
 public CRAN mirrors.
 }
 \keyword{environment}

--- a/man/repositories.Rd
+++ b/man/repositories.Rd
@@ -25,7 +25,7 @@ Named \code{character()} of repositories.
 \description{
 \code{repositories()} reports the URLs from which to
 install \emph{Bioconductor} and CRAN packages. It is used by
-\code{BiocManager::install()} and other functions.
+\code{\link[=install]{install()}} and other functions.
 }
 \details{
 \code{repositories()} returns the appropriate software package
@@ -88,16 +88,16 @@ BiocManager::repositories(version="3.8")
 
 }
 \seealso{
-\verb{BiocManager::\link{install}()} Installs or updates Bioconductor,
+\code{\link[=install]{install()}} Installs or updates Bioconductor,
 CRAN, and GitHub packages.
 
-\verb{\link{chooseBioCmirror}()} choose an alternative Bioconductor
+\code{\link[=chooseBioCmirror]{chooseBioCmirror()}} choose an alternative Bioconductor
 mirror; not usually necessary.
 
-\verb{\link{chooseCRANmirror}()} choose an alternative CRAN mirror; not
+\code{\link[=chooseCRANmirror]{chooseCRANmirror()}} choose an alternative CRAN mirror; not
 usually necessary.
 
-\verb{\link{setRepositories}()} Select additional repositories for
+\code{\link[=setRepositories]{setRepositories()}} Select additional repositories for
 searching.
 }
 \keyword{environment}

--- a/man/valid.Rd
+++ b/man/valid.Rd
@@ -20,31 +20,31 @@ valid(
 }
 \arguments{
 \item{pkgs}{A character() vector of package names for checking, or
-a matrix as returned by \verb{\link{installed.packages}}.}
+a matrix as returned by \code{\link{installed.packages}}.}
 
 \item{lib.loc}{A character() vector of library location(s) of
-packages to be validated; see \verb{\link{installed.packages}()}.}
+packages to be validated; see \code{\link[=installed.packages]{installed.packages()}}.}
 
 \item{priority}{character(1) Check validity of all, "base", or
-"recommended" packages; see \verb{\link{installed.packages}()}.}
+"recommended" packages; see \code{\link[=installed.packages]{installed.packages()}}.}
 
 \item{type}{character(1) The type of available package (e.g.,
 binary, source) to check validity against; see
-\verb{\link{available.packages}()}.}
+\code{\link[=available.packages]{available.packages()}}.}
 
 \item{filters}{character(1) Filter available packages to check
-validity against; see \verb{\link{available.packages}()}.}
+validity against; see \code{\link[=available.packages]{available.packages()}}.}
 
 \item{\dots}{Additional arguments, passed to
-\verb{BiocManager::\link{install}()} when \code{fix=TRUE}.}
+\code{\link[=install]{install()}} when \code{fix=TRUE}.}
 
 \item{checkBuilt}{\code{logical(1)}. If \code{TRUE} a package built under an
 earlier major.minor version of R (e.g., 3.4) is considered to
 be old.}
 
-\item{site_repository}{\code{character(1)}. See \code{?install}.}
+\item{site_repository}{\code{character(1)}. See \code{\link{install}}.}
 
-\item{x}{A `biocValid` object returned by `BiocManager::valid()`.}
+\item{x}{A \code{biocValid} object returned by \code{BiocManager::valid()}.}
 }
 \value{
 \code{biocValid} list object with elements \code{too_new} and
@@ -54,7 +54,7 @@ current version of \emph{Bioconductor}. When internet access
 is unavailable, an empty 'biocValid' list is returned. If all
 packages ('pkgs') are up to date, then TRUE is returned.
 
-`print()` is invoked for its side effect.
+\code{print()} is invoked for its side effect.
 }
 \description{
 Check that installed packages are consistent (neither out-of-date
@@ -63,19 +63,20 @@ nor too new) with the version of R and \emph{Bioconductor} in use.
 \details{
 This function compares the version of installed packages
 to the version of packages associated with the version of \emph{R}
-and \emph{Bioconductor} currently in use.\preformatted{Packages are reported as 'out-of-date' if a more recent version
+and \emph{Bioconductor} currently in use.
+
+Packages are reported as 'out-of-date' if a more recent version
 is available at the repositories specified by
-`BiocManager::repositories()`.  Usually, `BiocManager::install()` is
+\code{\link[=repositories]{repositories()}}.  Usually, \code{\link[=install]{install()}} is
 sufficient to update packages to their most recent version.
 
 Packages are reported as 'too new' if the installed version is
 more recent than the most recent available in the
-`BiocManager::repositories()`. It is possible to down-grade by
+\code{\link[=repositories]{repositories()}}. It is possible to down-grade by
 re-installing a too new package "PkgA" with
-`BiocManger::install("PkgA")`. It is important for the user to
+\code{BiocManger::install("PkgA")}. It is important for the user to
 understand how their installation became too new, and to avoid
 this in the future.
-}
 }
 \examples{
 if (interactive()) {
@@ -83,7 +84,7 @@ if (interactive()) {
 }
 }
 \seealso{
-\verb{BiocManager::\link{install}()} to update installed
+\code{\link[=install]{install()}} to update installed
 packages.
 }
 \author{


### PR DESCRIPTION
When reading your helpfiles I noticed that you had used a slightly incorrect syntax for your links. So I have fixed them with this PR. 

cheers
  Tom