### PR TITLE
update warning / message when packages are too new

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -78,8 +78,9 @@
         if (any(noInst))
             .warning(
                 paste(
-                    "package(s) not installed when version(s) same or greater",
-                    "than current; use `force = TRUE` to re-install: \n'%s'"
+                    "package(s) not installed when version(s) same as or",
+                    "greater than current; use `force = TRUE` to re-install: ",
+                    "\n'%s'"
                 ),
                 paste(pkgs[noInst], collapse = "' '")
             )

--- a/R/install.R
+++ b/R/install.R
@@ -78,8 +78,8 @@
         if (any(noInst))
             .warning(
                 paste(
-                    "package(s) not installed when version(s) same",
-                    "as current; use `force = TRUE` to re-install: \n'%s'"
+                    "package(s) not installed when version(s) same or greater",
+                    "than current; use `force = TRUE` to re-install: \n'%s'"
                 ),
                 paste(pkgs[noInst], collapse = "' '")
             )

--- a/R/valid.R
+++ b/R/valid.R
@@ -172,7 +172,7 @@ print.biocValid <-
         return()
     }
 
-    fmt <-'  BiocManager::install(%s, update = TRUE, ask = FALSE)'
+    fmt <-'  BiocManager::install(%s, update = TRUE, ask = FALSE, force = TRUE)'
     if (n == 1L) {
         fmt <- sprintf(fmt, '"%s"')
     } else {


### PR DESCRIPTION
- "same or greater than current"
- 'force = TRUE' added to valid() msg

Thanks to Hervé and Vince for noting. 