### PR TITLE
catch zero length output from .version_map_config_element

### DIFF
--- a/R/version.R
+++ b/R/version.R
@@ -137,6 +137,8 @@ format.version_sentinel <-
         return(.VERSION_MAP_SENTINEL)
 
     bioc_r_map <- .version_map_config_element(txt, "r_ver_for_bioc_ver")
+    if (!length(bioc_r_map))
+        return(.VERSION_MAP_SENTINEL)
     bioc <- package_version(names(bioc_r_map))
     r <- package_version(unname(bioc_r_map))
 

--- a/tests/testthat/test_version.R
+++ b/tests/testthat/test_version.R
@@ -270,6 +270,10 @@ test_that(".version_map() and BIOCONDUCTOR_CONFIG_FILE work", {
     expect_warning(
             .version_map_get_online_config("./fake/address/path/file.yaml")
     )
+    expect_identical(
+        .version_map_get_online(config),
+        .VERSION_MAP_SENTINEL
+    )
     skip_if_offline()
     expect_true(
         is.data.frame(


### PR DESCRIPTION
after timeout, related to #140