### PR TITLE
clean up checkBuilt in lower levels

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -193,14 +193,14 @@
 
 .install <-
     function(pkgs, old_pkgs, instPkgs, repos, lib.loc=NULL, lib=.libPaths()[1],
-        checkBuilt, update, ask, force, ...)
+        update, ask, force, ...)
 {
     requireNamespace("utils", quietly=TRUE) ||
         .stop("failed to load package 'utils'")
 
     todo <- .install_repos(
         pkgs, old_pkgs, instPkgs = instPkgs, lib = lib, repos = repos,
-        checkBuilt = checkBuilt, force = force, ...
+        force = force, ...
     )
     todo <- .install_github(
         todo, lib = lib, lib.loc = lib.loc, repos = repos,
@@ -431,7 +431,7 @@ install <-
 
     pkgs <- .install(
         pkgs, vout[["out_of_date"]], instPkgs = inst, repos = repos,
-        checkBuilt = checkBuilt, update = update, ask = ask, force = force, ...
+        update = update, ask = ask, force = force, ...
     )
     if (update && cmp == 0L) {
         .install_update(repos, ask, checkBuilt = checkBuilt, ...)

--- a/tests/testthat/test_install.R
+++ b/tests/testthat/test_install.R
@@ -319,6 +319,28 @@ test_that("install() passes the force argument to .install", {
             )
         )
     )    
+    expect_null(
+        with_mock(
+            `BiocManager:::.install` = function(...) {
+                list(...)[['checkBuilt']]
+            },
+            `BiocManager:::.version_compare` = function(...) {
+                1L
+            },
+            `BiocManager:::.install_n_invalid_pkgs` = function(...) {
+                0L
+            },
+            `BiocManager:::.install_updated_version` = function(...) {
+                pkgs <<- list(...)[['checkBuilt']]
+            },
+            suppressMessages(
+                install(
+                    force = FALSE, checkBuilt = TRUE,
+                    update = FALSE, ask = FALSE
+                )
+            )
+        )
+    )
 })
 
 test_that("install() without package names passes ... to install.packages", {


### PR DESCRIPTION
`checkBuilt` was used in the previous iteration of the function (to check for `valid` packages with `old.packages` and `update.packages`). The argument is no longer needed in those lower level functions. 