### PR TITLE
packageVersion to return NA of class package_version

### DIFF
--- a/R/version.R
+++ b/R/version.R
@@ -42,7 +42,7 @@
 {
     version <- package_version(NA, strict = FALSE)
     structure(
-        version,
+        unclass(version),
         msg = msg,
         class = c("version_sentinel", class(version))
     )
@@ -184,16 +184,7 @@ format.version_sentinel <-
 .version_map_get_offline <-
     function()
 {
-    bioc <- tryCatch({
-        .get_BiocVersion_version()
-    },
-        error = function(e) {
-            .version_sentinel(conditionMessage(e))
-        },
-        warning = function(w) {
-            .version_sentinel(conditionMessage(w))
-        }
-    )
+    bioc <- .get_BiocVersion_version()
     if (is.na(bioc))
         return(.VERSION_MAP_SENTINEL)
 
@@ -247,8 +238,18 @@ format.version_sentinel <-
 .get_R_version <- function()
     getRversion()
 
-.get_BiocVersion_version <- function()
-    packageVersion("BiocVersion")[, 1:2]
+.get_sys_file <- function()
+    system.file(package = "BiocVersion")
+
+.get_BiocVersion_version <-
+    function()
+{
+    if (nzchar(.get_sys_file())) {
+        packageVersion("BiocVersion")[, 1:2]
+    } else {
+        .version_sentinel("BiocVersion is not installed")
+    }
+}
 
 .version_string <-
     function(bioc_version = version())
@@ -467,16 +468,11 @@ format.version_sentinel <-
 version <-
     function()
 {
-    tryCatch({
-        .get_BiocVersion_version()
-    },
-        warning = function(w) {
-            .version_choose_best()
-        },
-        error = function(e) {
-            .version_choose_best()
-        }
-    )
+    bioc <- .get_BiocVersion_version()
+    if (is.na(bioc))
+        .version_choose_best()
+    else
+        bioc
 }
 
 .package_version <-

--- a/R/version.R
+++ b/R/version.R
@@ -445,18 +445,6 @@ format.version_sentinel <-
     version
 }
 
-.local_version <-
-    function()
-{
-    tryCatch({
-        .get_BiocVersion_version()
-    }, warning = function(w) {
-        .version_sentinel(conditionMessage(w))
-    }, error = function(e) {
-        .version_sentinel(conditionMessage(e))
-    })
-}
-
 #' Version of Bioconductor currently in use.
 #'
 #' `version()` reports the version of _Bioconductor_ appropropriate

--- a/R/version.R
+++ b/R/version.R
@@ -40,9 +40,9 @@
 .version_sentinel <-
     function(msg)
 {
-    version <- package_version(list())
+    version <- package_version(NA, strict = FALSE)
     structure(
-        unclass(version),
+        version,
         msg = msg,
         class = c("version_sentinel", class(version))
     )
@@ -184,10 +184,10 @@ format.version_sentinel <-
 .version_map_get_offline <-
     function()
 {
-    bioc <- tryCatch({
-        packageVersion("BiocVersion")[, 1:2]
-    }, error = identity)
-    if (inherits(bioc, "error"))
+    bioc <- suppressWarnings({
+       packageVersion("BiocVersion")[, 1:2]
+    })
+    if (is.na(bioc))
         return(.VERSION_MAP_SENTINEL)
 
     r <- package_version(R.Version())[,1:2]
@@ -440,8 +440,8 @@ format.version_sentinel <-
 {
     tryCatch({
         packageVersion("BiocVersion")[, 1:2]
-    }, error = function(e) {
-        .version_sentinel("package 'BiocVersion' not installed")
+    }, warning = function(w) {
+        .version_sentinel(conditionMessage(w))
     })
 }
 
@@ -469,7 +469,7 @@ version <-
 {
     tryCatch({
         packageVersion("BiocVersion")[, 1:2]
-    }, error = function(e) {
+    }, warning = function(w) {
         .version_choose_best()
     })
 }

--- a/R/version.R
+++ b/R/version.R
@@ -184,9 +184,16 @@ format.version_sentinel <-
 .version_map_get_offline <-
     function()
 {
-    bioc <- suppressWarnings({
-       .get_BiocVersion_version()
-    })
+    bioc <- tryCatch({
+        .get_BiocVersion_version()
+    },
+        error = function(e) {
+            .version_sentinel(conditionMessage(e))
+        },
+        warning = function(w) {
+            .version_sentinel(conditionMessage(w))
+        }
+    )
     if (is.na(bioc))
         return(.VERSION_MAP_SENTINEL)
 
@@ -445,6 +452,8 @@ format.version_sentinel <-
         .get_BiocVersion_version()
     }, warning = function(w) {
         .version_sentinel(conditionMessage(w))
+    }, error = function(e) {
+        .version_sentinel(conditionMessage(e))
     })
 }
 
@@ -472,9 +481,14 @@ version <-
 {
     tryCatch({
         .get_BiocVersion_version()
-    }, warning = function(w) {
-        .version_choose_best()
-    })
+    },
+        warning = function(w) {
+            .version_choose_best()
+        },
+        error = function(e) {
+            .version_choose_best()
+        }
+    )
 }
 
 .package_version <-

--- a/R/version.R
+++ b/R/version.R
@@ -185,12 +185,12 @@ format.version_sentinel <-
     function()
 {
     bioc <- suppressWarnings({
-       packageVersion("BiocVersion")[, 1:2]
+       .get_BiocVersion_version()
     })
     if (is.na(bioc))
         return(.VERSION_MAP_SENTINEL)
 
-    r <- package_version(R.Version())[,1:2]
+    r <- .get_R_version()[,1:2]
 
     status <- .VERSION_TAGS
     rbind(.VERSION_MAP_SENTINEL, data.frame(
@@ -239,6 +239,9 @@ format.version_sentinel <-
 
 .get_R_version <- function()
     getRversion()
+
+.get_BiocVersion_version <- function()
+    packageVersion("BiocVersion")[, 1:2]
 
 .version_string <-
     function(bioc_version = version())
@@ -439,7 +442,7 @@ format.version_sentinel <-
     function()
 {
     tryCatch({
-        packageVersion("BiocVersion")[, 1:2]
+        .get_BiocVersion_version()
     }, warning = function(w) {
         .version_sentinel(conditionMessage(w))
     })
@@ -468,7 +471,7 @@ version <-
     function()
 {
     tryCatch({
-        packageVersion("BiocVersion")[, 1:2]
+        .get_BiocVersion_version()
     }, warning = function(w) {
         .version_choose_best()
     })
@@ -495,5 +498,5 @@ version <-
 print.version_sentinel <-
     function(x, ...)
 {
-    cat(format(x), "\n")
+    cat(format(x), "\n", sep = "")
 }

--- a/R/version.R
+++ b/R/version.R
@@ -184,11 +184,11 @@ format.version_sentinel <-
 .version_map_get_offline <-
     function()
 {
-    bioc <- .get_BiocVersion_version()
+    bioc <- .version_BiocVersion()
     if (is.na(bioc))
         return(.VERSION_MAP_SENTINEL)
 
-    r <- .get_R_version()[,1:2]
+    r <- .version_R_version()[,1:2]
 
     status <- .VERSION_TAGS
     rbind(.VERSION_MAP_SENTINEL, data.frame(
@@ -235,20 +235,19 @@ format.version_sentinel <-
     map[idx, field]
 }
 
-.get_R_version <- function()
+.version_R_version <- function()
     getRversion()
 
-.get_sys_file <- function()
-    system.file(package = "BiocVersion")
+.version_BiocVersion_installed <- function()
+    nzchar(system.file(package = "BiocVersion"))
 
-.get_BiocVersion_version <-
+.version_BiocVersion <-
     function()
 {
-    if (nzchar(.get_sys_file())) {
+    if (.version_BiocVersion_installed())
         packageVersion("BiocVersion")[, 1:2]
-    } else {
+    else
         .version_sentinel("BiocVersion is not installed")
-    }
 }
 
 .version_string <-
@@ -266,7 +265,7 @@ format.version_sentinel <-
 ## the version is invalid. It does NOT call message / warning / etc
 ## directly.
 .version_validity <-
-    function(version, map = .version_map(), r_version = .get_R_version())
+    function(version, map = .version_map(), r_version = .version_R_version())
 {
     if (identical(version, "devel"))
         version <- .version_bioc("devel")
@@ -468,11 +467,11 @@ format.version_sentinel <-
 version <-
     function()
 {
-    bioc <- .get_BiocVersion_version()
+    bioc <- .version_BiocVersion()
     if (is.na(bioc))
-        .version_choose_best()
-    else
-        bioc
+        bioc <- .version_choose_best()
+
+    bioc
 }
 
 .package_version <-

--- a/tests/testthat/test_version.R
+++ b/tests/testthat/test_version.R
@@ -397,28 +397,22 @@ test_that(".version_sentinel() works", {
     )
 })
 
+test_that(".get_BiocVersion_version returns .version_sentinel output", {
+    with_mock(
+        `BiocManager:::.get_sys_file` = function(...) {
+            ""
+        },
+        expect_identical(
+            .get_BiocVersion_version(),
+            .version_sentinel("BiocVersion is not installed")
+        )
+    )
+})
+
 test_that(".version_map_get_offline() works", {
     with_mock(
         `BiocManager:::.get_BiocVersion_version` = function(...) {
-            package_version(NA, strict = FALSE)
-        },
-        expect_identical(
-            .version_map_get_offline(),
-            .VERSION_MAP_SENTINEL
-        )
-    )
-    with_mock(
-        `BiocManager:::.get_BiocVersion_version` = function(...) {
-            stop("there is no package called 'ABCD'")
-        },
-        expect_identical(
-            .version_map_get_offline(),
-            .VERSION_MAP_SENTINEL
-        )
-    )
-    with_mock(
-        `BiocManager:::.get_BiocVersion_version` = function(...) {
-            warning("no package 'ABCD' was found")
+            .version_sentinel("BiocVersion is not installed")
         },
         expect_identical(
             .version_map_get_offline(),
@@ -455,19 +449,7 @@ test_that("version chooses best", {
     )
     with_mock(
         `BiocManager:::.get_BiocVersion_version` = function(...) {
-            stop("there is no package called 'ABCD'")
-        },
-        `BiocManager:::.version_choose_best` = function(...) {
-            target_version
-        },
-        expect_identical(
-            version(),
-            target_version
-        )
-    )
-    with_mock(
-        `BiocManager:::.get_BiocVersion_version` = function(...) {
-            warning("no package 'ABCD' was found")
+            .version_sentinel("BiocVersion is not installed")
         },
         `BiocManager:::.version_choose_best` = function(...) {
             target_version

--- a/tests/testthat/test_version.R
+++ b/tests/testthat/test_version.R
@@ -407,6 +407,24 @@ test_that(".version_map_get_offline() works", {
             .VERSION_MAP_SENTINEL
         )
     )
+    with_mock(
+        `BiocManager:::.get_BiocVersion_version` = function(...) {
+            stop("there is no package called 'ABCD'")
+        },
+        expect_identical(
+            .version_map_get_offline(),
+            .VERSION_MAP_SENTINEL
+        )
+    )
+    with_mock(
+        `BiocManager:::.get_BiocVersion_version` = function(...) {
+            warning("no package 'ABCD' was found")
+        },
+        expect_identical(
+            .version_map_get_offline(),
+            .VERSION_MAP_SENTINEL
+        )
+    )
     .skip_if_misconfigured()
     skip_if_offline()
     rver <- package_version("4.3")
@@ -427,6 +445,36 @@ test_that(".version_map_get_offline() works", {
                 BiocStatus = factor(NA, levels = .VERSION_TAGS),
                 RSPM = NA_character_, MRAN = NA_character_
             ))
+        )
+    )
+})
+
+test_that("version chooses best", {
+    target_version <-  structure(
+        list(c(3L, 17L), class = c("package_version", "numeric_version"))
+    )
+    with_mock(
+        `BiocManager:::.get_BiocVersion_version` = function(...) {
+            stop("there is no package called 'ABCD'")
+        },
+        `BiocManager:::.version_choose_best` = function(...) {
+            target_version
+        },
+        expect_identical(
+            version(),
+            target_version
+        )
+    )
+    with_mock(
+        `BiocManager:::.get_BiocVersion_version` = function(...) {
+            warning("no package 'ABCD' was found")
+        },
+        `BiocManager:::.version_choose_best` = function(...) {
+            target_version
+        },
+        expect_identical(
+            version(),
+            target_version
         )
     )
 })

--- a/tests/testthat/test_version.R
+++ b/tests/testthat/test_version.R
@@ -397,13 +397,13 @@ test_that(".version_sentinel() works", {
     )
 })
 
-test_that(".get_BiocVersion_version returns .version_sentinel output", {
+test_that(".version_BiocVersion returns .version_sentinel output", {
     with_mock(
-        `BiocManager:::.get_sys_file` = function(...) {
-            ""
+        `BiocManager:::.version_BiocVersion_installed` = function(...) {
+            FALSE
         },
         expect_identical(
-            .get_BiocVersion_version(),
+            .version_BiocVersion(),
             .version_sentinel("BiocVersion is not installed")
         )
     )
@@ -411,7 +411,7 @@ test_that(".get_BiocVersion_version returns .version_sentinel output", {
 
 test_that(".version_map_get_offline() works", {
     with_mock(
-        `BiocManager:::.get_BiocVersion_version` = function(...) {
+        `BiocManager:::.version_BiocVersion` = function(...) {
             .version_sentinel("BiocVersion is not installed")
         },
         expect_identical(
@@ -424,10 +424,10 @@ test_that(".version_map_get_offline() works", {
     rver <- package_version("4.3")
     class(rver) <- c("R_system_version", class(rver))
     with_mock(
-        `BiocManager:::.get_BiocVersion_version` = function(...) {
+        `BiocManager:::.version_BiocVersion` = function(...) {
             package_version("3.14")
         },
-        `BiocManager:::.get_R_version` = function(...) {
+        `BiocManager:::.version_R_version` = function(...) {
             rver <- package_version("4.3")
             class(rver) <- c("R_system_version", class(rver))
             rver
@@ -448,7 +448,7 @@ test_that("version chooses best", {
         list(c(3L, 17L), class = c("package_version", "numeric_version"))
     )
     with_mock(
-        `BiocManager:::.get_BiocVersion_version` = function(...) {
+        `BiocManager:::.version_BiocVersion` = function(...) {
             .version_sentinel("BiocVersion is not installed")
         },
         `BiocManager:::.version_choose_best` = function(...) {


### PR DESCRIPTION
Based on ?packageVersion: 
```
 'packageVersion()' returns a (length-one) object of class
     '"package_version"'.
```
and can return `NA` when the package is not found. The change also addresses previous versions of R where an error would be emitted.
 