### PR TITLE
man: \link in backtick blocks not supported by roxygen2

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -285,13 +285,13 @@
 #' packages uses the `remotes::install_github()`.
 #'
 #' When installing CRAN or _Bioconductor_ packages, typical arguments
-#' include: `lib.loc`, passed to `\link{old.packages}()` and used to
+#' include: `lib.loc`, passed to \code{\link{old.packages}()} and used to
 #' determine the library location of installed packages to be updated;
-#' and `lib`, passed to `\link{install.packages}()` to determine the
+#' and `lib`, passed to \code{\link{install.packages}()} to determine the
 #' library location where `pkgs` are to be installed.
 #'
 #' When installing GitHub packages, `...` is passed to the
-#' \pkg{remotes} package functions `\link[remotes]{install_github}()`
+#' \pkg{remotes} package functions \code{\link[remotes]{install_github}()}
 #' and `remotes:::install()`. A typical use is to build vignettes, via
 #' `dependencies=TRUE, build_vignettes=TRUE`.
 #'
@@ -320,7 +320,7 @@
 #'     representing an additional repository in which to look for
 #'     packages to install. This repository will be prepended to the
 #'     default repositories (which you can see with
-#'     `BiocManager::\link{repositories}()`).
+#'     \code{BiocManager::\link{repositories}()}).
 #' @param update `logical(1)`. When `FALSE`, `BiocManager::install()`
 #'     does not attempt to update old packages. When `TRUE`, update
 #'     old packages according to `ask`.
@@ -342,19 +342,19 @@
 #' @return `BiocManager::install()` returns the `pkgs` argument, invisibly.
 #' @seealso
 #'
-#' `BiocManager::\link{repositories}()` returns the _Bioconductor_ and
-#' CRAN repositories used by `install()`.
+#' \code{BiocManager::\link{repositories}()} returns the _Bioconductor_
+#' and CRAN repositories used by `install()`.
 #'
-#' `\link{install.packages}()` installs the packages themselves (used by
-#' `BiocManager::install` internally).
+#' \code{\link{install.packages}()} installs the packages themselves
+#' (used by \code{BiocManager::install} internally).
 #'
-#' `\link{update.packages}()` updates all installed packages (used by
-#' `BiocManager::install` internally).
+#' \code{\link{update.packages}()} updates all installed packages (used
+#' by \code{BiocManager::install} internally).
 #'
-#' `\link{chooseBioCmirror}()` allows choice of a mirror from all
+#' \code{\link{chooseBioCmirror}()} allows choice of a mirror from all
 #' public _Bioconductor_ mirrors.
 #'
-#' `\link{chooseCRANmirror}()` allows choice of a mirror from all
+#' \code{\link{chooseCRANmirror}()} allows choice of a mirror from all
 #' public CRAN mirrors.
 #'
 #' @keywords environment

--- a/R/repositories.R
+++ b/R/repositories.R
@@ -248,16 +248,16 @@ BINARY_BASE_URL <- "https://bioconductor.org/packages/%s/container-binaries/%s"
 #'
 #' @seealso
 #'
-#' `BiocManager::\link{install}()` Installs or updates Bioconductor,
+#' \code{BiocManager::\link{install}()} Installs or updates Bioconductor,
 #'  CRAN, and GitHub packages.
 #'
-#' `\link{chooseBioCmirror}()` choose an alternative Bioconductor
+#' \code{\link{chooseBioCmirror}()} choose an alternative Bioconductor
 #' mirror; not usually necessary.
 #'
-#' `\link{chooseCRANmirror}()` choose an alternative CRAN mirror; not
-#' usually necessary.
+#' \code{\link{chooseCRANmirror}()} choose an alternative CRAN mirror;
+#' not usually necessary.
 #'
-#' `\link{setRepositories}()` Select additional repositories for
+#' \code{\link{setRepositories}()} Select additional repositories for
 #' searching.
 #'
 #' @keywords environment

--- a/R/valid.R
+++ b/R/valid.R
@@ -73,18 +73,18 @@
 #'   this in the future.
 #'
 #' @param pkgs A character() vector of package names for checking, or
-#'     a matrix as returned by `\link{installed.packages}`.
+#'     a matrix as returned by \code{\link{installed.packages}}.
 #' @param lib.loc A character() vector of library location(s) of
-#'     packages to be validated; see `\link{installed.packages}()`.
+#'     packages to be validated; see \code{\link{installed.packages}()}.
 #' @param priority character(1) Check validity of all, "base", or
-#'     "recommended" packages; see `\link{installed.packages}()`.
+#'     "recommended" packages; see \code{\link{installed.packages}()}.
 #' @param type character(1) The type of available package (e.g.,
 #'     binary, source) to check validity against; see
-#'     `\link{available.packages}()`.
+#'     \code{\link{available.packages}()}.
 #' @param filters character(1) Filter available packages to check
-#'     validity against; see `\link{available.packages}()`.
+#'     validity against; see \code{\link{available.packages}()}.
 #' @param \dots Additional arguments, passed to
-#'     `BiocManager::\link{install}()` when `fix=TRUE`.
+#'     \code{BiocManager::\link{install}()} when \code{fix=TRUE}.
 #' @param checkBuilt `logical(1)`. If `TRUE` a package built under an
 #'     earlier major.minor version of R (e.g., 3.4) is considered to
 #'     be old.
@@ -96,7 +96,7 @@
 #'     is unavailable, an empty 'biocValid' list is returned. If all
 #'     packages ('pkgs') are up to date, then TRUE is returned.
 #' @author Martin Morgan \email{martin.morgan@@roswellpark.org}
-#' @seealso `BiocManager::\link{install}()` to update installed
+#' @seealso \code{BiocManager::\link{install}()} to update installed
 #'     packages.
 #' @keywords environment
 #' @examples

--- a/man/install.Rd
+++ b/man/install.Rd
@@ -29,7 +29,7 @@ treated as GitHub repositories and installed using
 representing an additional repository in which to look for
 packages to install. This repository will be prepended to the
 default repositories (which you can see with
-\verb{BiocManager::\link{repositories}()}).}
+\code{BiocManager::\link{repositories}()}).}
 
 \item{update}{\code{logical(1)}. When \code{FALSE}, \code{BiocManager::install()}
 does not attempt to update old packages. When \code{TRUE}, update
@@ -69,13 +69,13 @@ functions for library management -- \code{install.packages()},
 packages uses the \code{remotes::install_github()}.
 
 When installing CRAN or \emph{Bioconductor} packages, typical arguments
-include: \code{lib.loc}, passed to \verb{\link{old.packages}()} and used to
+include: \code{lib.loc}, passed to \code{\link{old.packages}()} and used to
 determine the library location of installed packages to be updated;
-and \code{lib}, passed to \verb{\link{install.packages}()} to determine the
+and \code{lib}, passed to \code{\link{install.packages}()} to determine the
 library location where \code{pkgs} are to be installed.
 
 When installing GitHub packages, \code{...} is passed to the
-\pkg{remotes} package functions \verb{\link[remotes]\{install_github\}()}
+\pkg{remotes} package functions \code{\link[remotes]{install_github}()}
 and \code{remotes:::install()}. A typical use is to build vignettes, via
 \verb{dependencies=TRUE, build_vignettes=TRUE}.
 
@@ -113,19 +113,19 @@ BiocManager::install("IRanges", type="source")
 
 }
 \seealso{
-\verb{BiocManager::\link{repositories}()} returns the \emph{Bioconductor} and
-CRAN repositories used by \code{install()}.
+\code{BiocManager::\link{repositories}()} returns the \emph{Bioconductor}
+and CRAN repositories used by \code{install()}.
 
-\verb{\link{install.packages}()} installs the packages themselves (used by
-\code{BiocManager::install} internally).
+\code{\link{install.packages}()} installs the packages themselves
+(used by \code{BiocManager::install} internally).
 
-\verb{\link{update.packages}()} updates all installed packages (used by
-\code{BiocManager::install} internally).
+\code{\link{update.packages}()} updates all installed packages (used
+by \code{BiocManager::install} internally).
 
-\verb{\link{chooseBioCmirror}()} allows choice of a mirror from all
+\code{\link{chooseBioCmirror}()} allows choice of a mirror from all
 public \emph{Bioconductor} mirrors.
 
-\verb{\link{chooseCRANmirror}()} allows choice of a mirror from all
+\code{\link{chooseCRANmirror}()} allows choice of a mirror from all
 public CRAN mirrors.
 }
 \keyword{environment}

--- a/man/repositories.Rd
+++ b/man/repositories.Rd
@@ -134,16 +134,16 @@ containerRepository() # character(0) if not within a Bioconductor container
 
 }
 \seealso{
-\verb{BiocManager::\link{install}()} Installs or updates Bioconductor,
+\code{BiocManager::\link{install}()} Installs or updates Bioconductor,
 CRAN, and GitHub packages.
 
-\verb{\link{chooseBioCmirror}()} choose an alternative Bioconductor
+\code{\link{chooseBioCmirror}()} choose an alternative Bioconductor
 mirror; not usually necessary.
 
-\verb{\link{chooseCRANmirror}()} choose an alternative CRAN mirror; not
-usually necessary.
+\code{\link{chooseCRANmirror}()} choose an alternative CRAN mirror;
+not usually necessary.
 
-\verb{\link{setRepositories}()} Select additional repositories for
+\code{\link{setRepositories}()} Select additional repositories for
 searching.
 }
 \keyword{environment}

--- a/man/valid.Rd
+++ b/man/valid.Rd
@@ -20,23 +20,23 @@ valid(
 }
 \arguments{
 \item{pkgs}{A character() vector of package names for checking, or
-a matrix as returned by \verb{\link{installed.packages}}.}
+a matrix as returned by \code{\link{installed.packages}}.}
 
 \item{lib.loc}{A character() vector of library location(s) of
-packages to be validated; see \verb{\link{installed.packages}()}.}
+packages to be validated; see \code{\link{installed.packages}()}.}
 
 \item{priority}{character(1) Check validity of all, "base", or
-"recommended" packages; see \verb{\link{installed.packages}()}.}
+"recommended" packages; see \code{\link{installed.packages}()}.}
 
 \item{type}{character(1) The type of available package (e.g.,
 binary, source) to check validity against; see
-\verb{\link{available.packages}()}.}
+\code{\link{available.packages}()}.}
 
 \item{filters}{character(1) Filter available packages to check
-validity against; see \verb{\link{available.packages}()}.}
+validity against; see \code{\link{available.packages}()}.}
 
 \item{\dots}{Additional arguments, passed to
-\verb{BiocManager::\link{install}()} when \code{fix=TRUE}.}
+\code{BiocManager::\link{install}()} when \code{fix=TRUE}.}
 
 \item{checkBuilt}{\code{logical(1)}. If \code{TRUE} a package built under an
 earlier major.minor version of R (e.g., 3.4) is considered to
@@ -84,7 +84,7 @@ if (interactive()) {
 }
 }
 \seealso{
-\verb{BiocManager::\link{install}()} to update installed
+\code{BiocManager::\link{install}()} to update installed
 packages.
 }
 \author{


### PR DESCRIPTION
See, e.g.:
https://github.com/Bioconductor/BiocManager/blob/9ec84b1a623ddd6d70decca3cc8ae5dfff5881eb/R/install.R#L288
...which is rendered as:
https://github.com/Bioconductor/BiocManager/blob/9ec84b1a623ddd6d70decca3cc8ae5dfff5881eb/man/install.Rd#L72

and results in literal `\link{old.packages}` in the help output instead of a link to `?old.packages`.

Since [transitioning backtick blocks from `\code` to `\verb`](https://github.com/r-lib/roxygen2/pull/903) (for good reasons: they are supposed to be parseable as R), roxygen2 doesn't support the `\link` syntax inside code blocks.

The new [`[old.packages]` and `[remotes::install_github()]`](https://roxygen2.r-lib.org/articles/rd-formatting.html#function-links) syntax seems to result in the right Rd output.