### PR TITLE
Add site_repository environment variable and option

### DIFF
--- a/R/BiocManager-pkg.R
+++ b/R/BiocManager-pkg.R
@@ -55,6 +55,18 @@ NULL
 #'   configuration to avoid _Bioconductor_ version checks. See
 #'   `?install`.
 #'
+#' - \env{BIOCONDUCTOR_CONFIG_FILE} for offline use of BiocManager
+#'   versioning functionality. See `?install`.
+#'
+#' - \env{BIOCONDUCTOR_USE_CONTAINER_REPOSITORY} opt out of binary package
+#'   installations. See `?containerRepository`.
+#'
+#' - \env{BIOCMANAGER_CHECK_REPOSITORIES} silence messages regarding
+#'   non-standard CRAN or Bioconductor repositories. See `?repositories`.
+#'
+#' - \env{BIOCMANAGER_SITE_REPOSITORY} configure a more permanent
+#'   `site_repository` input to `repositories()`. See `?repositories`.
+#'
 #' @md
 #' @name BiocManager-pkg
 #' @aliases BiocManager

--- a/R/repositories.R
+++ b/R/repositories.R
@@ -8,6 +8,17 @@ BINARY_BASE_URL <- "https://bioconductor.org/packages/%s/container-binaries/%s"
     isTRUE(as.logical(opt))
 }
 
+.repositories_site_repository <-
+    function()
+{
+    opt <- Sys.getenv("BIOCMANAGER_SITE_REPOSITORY", "")
+    opt <- getOption("BiocManager.site_repository", opt)
+    if (!nzchar(opt))
+        character()
+    else
+        opt
+}
+
 .repositories_check_repos <-
     function(repos)
 {
@@ -276,6 +287,9 @@ repositories <- function(
     ...,
     type = "both"
 ) {
+    if (!nzchar(site_repository))
+        site_repository <- .repositories_site_repository()
+
     stopifnot(
         length(site_repository) <= 1L,
         is.character(site_repository), !anyNA(site_repository)

--- a/R/repositories.R
+++ b/R/repositories.R
@@ -290,7 +290,7 @@ repositories <- function(
     ...,
     type = "both"
 ) {
-    if (!nzchar(site_repository))
+    if (!length(site_repository) || !nzchar(site_repository))
         site_repository <- .repositories_site_repository()
 
     stopifnot(

--- a/R/repositories.R
+++ b/R/repositories.R
@@ -249,6 +249,9 @@ BINARY_BASE_URL <- "https://bioconductor.org/packages/%s/container-binaries/%s"
 #' that _R_'s standard rules of package selection apply, so the most
 #' recent version of candidate packages is selected independent of the
 #' location of the repository in the vector returned by `repositories()`.
+#' To set a more permenanent `site_repository`, one can use either the
+#' \env{BIOCMANAGER_SITE_REPOSITORY} environment variable or the
+#' `options(BiocManager.site_repository = ...)` option.
 #'
 #' For greater flexiblity in installing packages while still adhering
 #' as much as possible to _Bioconductor_ best practices, use

--- a/man/BiocManager-pkg.Rd
+++ b/man/BiocManager-pkg.Rd
@@ -52,6 +52,14 @@ System environment variables influencing package behavior include:
 \item \env{BIOCONDUCTOR_ONLINE_VERSION_DIAGNOSIS} advanced
 configuration to avoid \emph{Bioconductor} version checks. See
 \code{?install}.
+\item \env{BIOCONDUCTOR_CONFIG_FILE} for offline use of BiocManager
+versioning functionality. See \code{?install}.
+\item \env{BIOCONDUCTOR_USE_CONTAINER_REPOSITORY} opt out of binary package
+installations. See \code{?containerRepository}.
+\item \env{BIOCMANAGER_CHECK_REPOSITORIES} silence messages regarding
+non-standard CRAN or Bioconductor repositories. See \code{?repositories}.
+\item \env{BIOCMANAGER_SITE_REPOSITORY} configure a more permanent
+\code{site_repository} input to \code{repositories()}. See \code{?repositories}.
 }
 }
 \examples{

--- a/man/repositories.Rd
+++ b/man/repositories.Rd
@@ -110,6 +110,9 @@ binaries) of packages available in the default repositories. Note
 that \emph{R}'s standard rules of package selection apply, so the most
 recent version of candidate packages is selected independent of the
 location of the repository in the vector returned by \code{repositories()}.
+To set a more permenanent \code{site_repository}, one can use either the
+\env{BIOCMANAGER_SITE_REPOSITORY} environment variable or the
+\code{options(BiocManager.site_repository = ...)} option.
 
 For greater flexiblity in installing packages while still adhering
 as much as possible to \emph{Bioconductor} best practices, use


### PR DESCRIPTION
Add `BiocManager.site_repository` option and environment variable checks to make `site_repository` argument more permanent. 