### PR TITLE
use Bioc-devel branch on R-devel during the 'summer' release cycle

### DIFF
--- a/R/version.R
+++ b/R/version.R
@@ -308,7 +308,7 @@ format.version_sentinel <-
         } else {
             rec_fun <- ifelse("devel" %in% rec$BiocStatus, head, tail)
             rec_msg <- sprintf(
-                "use `BiocManager::install(version = '%s')` with R version %s",
+                "use `version = '%s'` with R version %s",
                 rec_fun(rec$Bioc, 1), r_version
             )
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,7 +3,7 @@
 {
     version <- version()
 
-    validity <- .version_validity(version)
+    validity <- .version_validity(version, check_future = TRUE)
     isTRUE(validity) || .packageStartupMessage(validity)
 
     if (interactive() && isTRUE(validity))


### PR DESCRIPTION
This PR supports use of Bioconductor with R-devel during the 'summer' release cycle, even though Bioconductor does not build or check against R-devel during this time.

- Discussion at https://github.com/Bioconductor/pkgrevdocs/issues/108 
- A startup message informs of this non-standard use
    ```
    Bioconductor does not yet build and check packages for R version 4.4, using
      unsupported Bioconductor version 3.18; see https://bioconductor.org/install
    ```
- Binaries are not available, so macOS / Windows users must set `options(pkgType = "source")` when using R-devel

- closes #133