### PR TITLE
filter BiocVersion from out_of_date matrix in .valid_result

### DIFF
--- a/R/valid.R
+++ b/R/valid.R
@@ -32,14 +32,18 @@
     )
 }
 
+.valid_out_of_date_filter <- function(out_of_date) {
+    out_of_date[rownames(out_of_date) != "BiocVersion", , drop = FALSE]
+}
+
 .valid_result <-
     function(avail_out, pkgs = installed.packages(lib.loc, priority=priority),
              lib.loc=NULL, priority="NA")
 {
     too_new <- .valid_pkgs_too_new(pkgs, avail_out[["available"]])
-    out_of_date <- avail_out[["out_of_date"]]
+    out_of_date <- .valid_out_of_date_filter(avail_out[["out_of_date"]])
 
-    result <- !nrow(too_new) && is.null(out_of_date)
+    result <- !nrow(too_new) && (is.null(out_of_date) || !nrow(out_of_date))
 
     if (!result || avail_out[["noRepos"]]) {
         result <- structure(

--- a/tests/testthat/test_valid.R
+++ b/tests/testthat/test_valid.R
@@ -18,3 +18,55 @@ test_that("valid returns an empty list without internet", {
         c(out_of_date = 0L, too_new = 0L)
     )
 })
+
+test_that("out of date filtering of BiocVersion works", {
+    expect_null(
+        .valid_out_of_date_filter(NULL)
+    )
+    out_data_names <-  c(
+        "Package", "LibPath", "Installed", "Built", "ReposVer", "Repository"
+    )
+    valid_out <- matrix(
+        data = c(
+            "BiocVersion", "/unit/test/lib/path", "3.17.1", "4.3.0",
+            "3.18.0", "https://bioconductor.org/packages/3.18/bioc/src/contrib"
+        ),
+        nrow = 1, byrow = TRUE,
+        dimnames = list(
+            "BiocVersion",
+            out_data_names
+        )
+    )
+    expect_identical(
+        .valid_out_of_date_filter(valid_out),
+        matrix(
+            data = character(0), nrow = 0,
+            ncol = length(out_data_names),
+            dimnames = list(NULL, out_data_names)
+        )
+    )
+    valid_out <- matrix(
+        data = c(
+            "BiocVersion", "/unit/test/lib/path", "3.17.1", "4.3.0",
+            "3.18.0", "https://bioconductor.org/packages/3.18/bioc/src/contrib",
+            "apackage", "/unit/test/lib/path", "3.17.1", "4.3.0",
+            "3.18.0", "https://bioconductor.org/packages/3.18/bioc/src/contrib"
+        ),
+        nrow = 2, byrow = TRUE,
+        dimnames = list(
+            c("BiocVersion", "apackage"),
+            out_data_names
+        )
+    )
+    expect_identical(
+        .valid_out_of_date_filter(valid_out),
+        matrix(
+            data = c(
+                "apackage", "/unit/test/lib/path", "3.17.1", "4.3.0", "3.18.0",
+                "https://bioconductor.org/packages/3.18/bioc/src/contrib"
+            ),
+            nrow = 1, byrow = TRUE,
+            dimnames = list("apackage", out_data_names)
+        )
+    )
+})


### PR DESCRIPTION
This filters out the `BiocVersion` row in the `out_of_date` matrix to avoid counting the package twice particularly when updating Bioconductor from release to devel (on the same R version). 
It resolves #168. 