### PR TITLE
add default BioC_mirror for CI=TRUE env

### DIFF
--- a/R/repositories.R
+++ b/R/repositories.R
@@ -76,14 +76,13 @@
     isTRUE(as.logical(opt)) && as.logical(Sys.getenv("CI", FALSE))
 }
 
-.repositories_config_mirror_element <- function(config) {
-    txt <- .version_map_read_online(config)
+.repositories_config_mirror_element <- function(txt) {
     section <- .version_config_section(txt, "^[^[:blank:]]", "mirrors:")
     section <- .version_config_section(
         trimws(section), "-\\sinstitution:.*", "Bioconductor.*CI.*"
     )
-    m_value <- Filter(function(x) startsWith(x, "https_mirror_url"), section)
-    murl <- sub("https_mirror_url: (.*)", "\\1", m_value)
+    mvalue <- Filter(function(x) startsWith(x, "https_mirror_url"), section)
+    murl <- sub("https_mirror_url:\\s*(.*)", "\\1", mvalue)
     if (!length(murl) || !nzchar(murl))
         murl <- "https://bioconductor.org"
     murl
@@ -93,13 +92,15 @@
     function(config)
 {
     mirror <- "https://bioconductor.org"
-    if (.repositories_ci_mirror_envopt())
-        mirror <- .repositories_config_mirror_element(config)
+    if (.repositories_ci_mirror_envopt()) {
+        txt <- .version_map_read_online(config)
+        mirror <- .repositories_config_mirror_element(txt)
+    }
     mirror
 }
 
 .repositories_bioc_mirror <- function() {
-    mirror_url <- .repositories_read_bioc_mirrors(
+    mirror_url <- .repositories_read_bioc_mirror(
         "https://bioconductor.org/config.yaml"
     )
     getOption("BioC_mirror", mirror_url)

--- a/R/repositories.R
+++ b/R/repositories.R
@@ -76,32 +76,32 @@
     isTRUE(as.logical(opt)) && as.logical(Sys.getenv("CI", FALSE))
 }
 
-.repositories_config_mirror_element <- function(txt, tag) {
-    section <- .version_config_section(txt, "^[^[:blank:]]", tag)
+.repositories_config_mirror_element <- function(config) {
+    txt <- .version_map_read_online(config)
+    section <- .version_config_section(txt, "^[^[:blank:]]", "mirrors:")
     section <- .version_config_section(
         trimws(section), "-\\sinstitution:.*", "Bioconductor.*CI.*"
     )
-    mkey_val <- Filter(function(x) startsWith(x, "https_mirror_url"), section)
-    sub("https_mirror_url: (.*)", "\\1", mkey_val)
+    m_value <- Filter(function(x) startsWith(x, "https_mirror_url"), section)
+    murl <- sub("https_mirror_url: (.*)", "\\1", m_value)
+    if (!length(murl) || !nzchar(murl))
+        murl <- "https://bioconductor.org"
+    murl
 }
 
 .repositories_read_bioc_mirrors <-
     function(config)
 {
-    txt <- .version_map_read_online(config)
-    mirror <- .repositories_config_mirror_element(txt, "mirrors:")
-    if (!length(mirror) || !nzchar(mirror))
-        mirror <- "https://bioconductor.org"
+    mirror <- "https://bioconductor.org"
+    if (.repositories_ci_mirror_envopt())
+        mirror <- .repositories_config_mirror_element(config)
     mirror
 }
 
 .repositories_bioc_mirror <- function() {
-    if (.repositories_ci_mirror_envopt())
-        mirror_url <- .repositories_read_bioc_mirrors(
-            config = "https://bioconductor.org/config.yaml"
-        )
-    else
-        mirror_url <- "https://bioconductor.org"
+    mirror_url <- .repositories_read_bioc_mirrors(
+        "https://bioconductor.org/config.yaml"
+    )
     getOption("BioC_mirror", mirror_url)
 }
 

--- a/R/repositories.R
+++ b/R/repositories.R
@@ -3,9 +3,9 @@ BINARY_BASE_URL <- "https://bioconductor.org/packages/%s/container-binaries/%s"
 .repositories_check_repos_envopt <-
     function()
 {
-    opt <- Sys.getenv("BIOCMANAGER_CHECK_REPOSITORIES", TRUE)
-    opt <- getOption("BiocManager.check_repositories", opt)
-    isTRUE(as.logical(opt))
+    .env_opt_lgl(
+        "BIOCMANAGER_CHECK_REPOSITORIES", "BiocManager.check_repositories", TRUE
+    )
 }
 
 .repositories_site_repository <-
@@ -68,11 +68,30 @@ BINARY_BASE_URL <- "https://bioconductor.org/packages/%s/container-binaries/%s"
     repos
 }
 
+.repositories_ci_mirror_envopt <-
+    function()
+{
+    .env_opt_lgl(
+        "BIOCMANAGER_USE_CI_MIRROR", "BiocManager.use_ci_mirror", TRUE
+    ) && as.logical(Sys.getenv("CI"))
+}
+
+.BIOCONDUCTOR_CI_MIRROR <- "https://ci-mirror.bioconductor.org"
+
+.repositories_bioc_mirror <- function() {
+    if (
+        .repositories_ci_mirror_envopt() && .url_exists(.BIOCONDUCTOR_CI_MIRROR)
+    )
+        .BIOCONDUCTOR_CI_MIRROR
+    else
+        getOption("BioC_mirror", "https://bioconductor.org")
+}
+
 #' @importFrom stats setNames
 .repositories_bioc <-
     function(version, ..., type = NULL)
 {
-    mirror <- getOption("BioC_mirror", "https://bioconductor.org")
+    mirror <- .repositories_bioc_mirror()
     paths <- c(
         BioCsoft = "bioc",
         BioCann = "data/annotation",
@@ -256,9 +275,11 @@ repositories <- function(
 .repositories_use_container_repo <-
     function()
 {
-    opt <- Sys.getenv("BIOCONDUCTOR_USE_CONTAINER_REPOSITORY", TRUE)
-    opt <- getOption("BIOCONDUCTOR_USE_CONTAINER_REPOSITORY", opt)
-    isTRUE(as.logical(opt))
+    .env_opt_lgl(
+        "BIOCONDUCTOR_USE_CONTAINER_REPOSITORY",
+        "BIOCONDUCTOR_USE_CONTAINER_REPOSITORY",
+        TRUE
+    )
 }
 
 #' @rdname repositories

--- a/R/repositories.R
+++ b/R/repositories.R
@@ -1,4 +1,5 @@
 .BINARY_SLUG_URL <- "/packages/%s/container-binaries/%s"
+.BIOC_DOMAIN_URL <- "https://bioconductor.org"
 
 .repositories_check_repos_envopt <-
     function()
@@ -76,25 +77,27 @@
     isTRUE(as.logical(opt)) && as.logical(Sys.getenv("CI", FALSE))
 }
 
-.repositories_config_mirror_element <- function(txt) {
+.repositories_config_mirror_url <- function(txt) {
     section <- .version_config_section(txt, "^[^[:blank:]]", "mirrors:")
     section <- .version_config_section(
         trimws(section), "-\\sinstitution:.*", "Bioconductor.*CI.*"
     )
-    mvalue <- Filter(function(x) startsWith(x, "https_mirror_url"), section)
-    murl <- sub("https_mirror_url:\\s*(.*)", "\\1", mvalue)
-    if (!length(murl) || !nzchar(murl))
-        murl <- "https://bioconductor.org"
-    murl
+    mirror_value <- Filter(
+        function(x) startsWith(x, "https_mirror_url"), section
+    )
+    mirror <- sub("https_mirror_url:\\s*(.*)", "\\1", mirror_value)
+    if (!length(mirror) || !nzchar(mirror))
+        mirror <- .BIOC_DOMAIN_URL
+    mirror
 }
 
-.repositories_read_bioc_mirrors <-
+.repositories_read_bioc_mirror <-
     function(config)
 {
-    mirror <- "https://bioconductor.org"
+    mirror <- .BIOC_DOMAIN_URL
     if (.repositories_ci_mirror_envopt()) {
         txt <- .version_map_read_online(config)
-        mirror <- .repositories_config_mirror_element(txt)
+        mirror <- .repositories_config_mirror_url(txt)
     }
     mirror
 }
@@ -383,7 +386,7 @@ containerRepository <-
         FUN = function(...) {
             .repositories_try_url_con(
                 version = version,
-                mirror = "https://bioconductor.org",
+                mirror = .BIOC_DOMAIN_URL,
                 platform = platform,
                 FUN = character
             )

--- a/R/repositories.R
+++ b/R/repositories.R
@@ -96,9 +96,7 @@ BINARY_SLUG_URL <- "/packages/%s/container-binaries/%s"
 }
 
 .repositories_bioc_mirror <- function() {
-    if (
-        .repositories_ci_mirror_envopt() && .url_exists(.BIOCONDUCTOR_CI_MIRROR)
-    )
+    if (.repositories_ci_mirror_envopt())
         mirror_url <- .repositories_read_bioc_mirrors(
             config = "https://bioconductor.org/config.yaml"
         )

--- a/R/repositories.R
+++ b/R/repositories.R
@@ -3,9 +3,9 @@ BINARY_BASE_URL <- "https://bioconductor.org/packages/%s/container-binaries/%s"
 .repositories_check_repos_envopt <-
     function()
 {
-    .env_opt_lgl(
-        "BIOCMANAGER_CHECK_REPOSITORIES", "BiocManager.check_repositories", TRUE
-    )
+    opt <- Sys.getenv("BIOCMANAGER_CHECK_REPOSITORIES", TRUE)
+    opt <- getOption("BiocManager.check_repositories", opt)
+    isTRUE(as.logical(opt))
 }
 
 .repositories_site_repository <-
@@ -71,9 +71,9 @@ BINARY_BASE_URL <- "https://bioconductor.org/packages/%s/container-binaries/%s"
 .repositories_ci_mirror_envopt <-
     function()
 {
-    .env_opt_lgl(
-        "BIOCMANAGER_USE_CI_MIRROR", "BiocManager.use_ci_mirror", TRUE
-    ) && as.logical(Sys.getenv("CI"))
+    opt <- Sys.getenv("BIOCMANAGER_USE_CI_MIRROR", TRUE)
+    opt <- getOption("BiocManager.use_ci_mirror", opt)
+    isTRUE(as.logical(opt)) && as.logical(Sys.getenv("CI"))
 }
 
 .BIOCONDUCTOR_CI_MIRROR <- "https://ci-mirror.bioconductor.org"
@@ -275,11 +275,9 @@ repositories <- function(
 .repositories_use_container_repo <-
     function()
 {
-    .env_opt_lgl(
-        "BIOCONDUCTOR_USE_CONTAINER_REPOSITORY",
-        "BIOCONDUCTOR_USE_CONTAINER_REPOSITORY",
-        TRUE
-    )
+    opt <- Sys.getenv("BIOCONDUCTOR_USE_CONTAINER_REPOSITORY", TRUE)
+    opt <- getOption("BIOCONDUCTOR_USE_CONTAINER_REPOSITORY", opt)
+    isTRUE(as.logical(opt))
 }
 
 #' @rdname repositories

--- a/R/repositories.R
+++ b/R/repositories.R
@@ -77,9 +77,7 @@ BINARY_SLUG_URL <- "/packages/%s/container-binaries/%s"
 }
 
 .repositories_config_mirror_element <- function(txt, tag) {
-    section <- .version_config_section(
-        txt = txt, grp = "^[^[:blank:]]", tag = tag
-    )
+    section <- .version_config_section(txt, "^[^[:blank:]]", tag)
     section <- .version_config_section(
         trimws(section), "-\\sinstitution:.*", "Bioconductor.*CI.*"
     )

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -33,6 +33,12 @@
     }
 }
 
+.env_opt_lgl <- function(envvar, option, default) {
+    opt <- Sys.getenv(envvar, default)
+    opt <- getOption(option, opt)
+    isTRUE(as.logical(opt))
+}
+
 .sQuote <- function(x)
     sprintf("'%s'", as.character(x))
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -33,12 +33,6 @@
     }
 }
 
-.env_opt_lgl <- function(envvar, option, default) {
-    opt <- Sys.getenv(envvar, default)
-    opt <- getOption(option, opt)
-    isTRUE(as.logical(opt))
-}
-
 .sQuote <- function(x)
     sprintf("'%s'", as.character(x))
 

--- a/R/version.R
+++ b/R/version.R
@@ -100,26 +100,27 @@ format.version_sentinel <-
     txt
 }
 
-.version_map_config_element <-
-    function(txt, tag)
-{
+.version_config_section <- function(txt, tag) {
     grps <- grep("^[^[:blank:]]", txt)
     start <- match(grep(tag, txt), grps)
     if (!length(start))
         return(setNames(character(), character()))
     end <- ifelse(length(grps) < start + 1L, length(txt), grps[start + 1] - 1L)
-    map <- txt[seq(grps[start] + 1, end)]
-    map <- trimws(gsub("\"", "", sub(" #.*", "", map)))
+    txt[seq(grps[start] + 1, end)]
+}
 
+.version_map_config_element <-
+    function(txt, tag)
+{
+    map <- .version_config_section(txt = txt, tag = tag)
+    map <- trimws(gsub("\"", "", sub(" #.*", "", map)))
     pattern <- "(.*): (.*)"
     key <- sub(pattern, "\\1", map)
     value <- sub(pattern, "\\2", map)
     setNames(value, key)
 }
 
-.version_map_get_online <-
-    function(config)
-{
+.version_map_read_online <- function(config) {
     toggle_warning <- FALSE
     withCallingHandlers({
         txt <- .version_map_get_online_config(config)
@@ -130,7 +131,13 @@ format.version_sentinel <-
     })
     if (toggle_warning)
         .VERSION_MAP$WARN_NO_ONLINE_CONFIG <- FALSE
+    txt
+}
 
+.version_map_get_online <-
+    function(config)
+{
+    txt <- .version_map_read_online(config = config)
     if (!length(txt) || inherits(txt, "error"))
         return(.VERSION_MAP_SENTINEL)
 
@@ -170,7 +177,7 @@ format.version_sentinel <-
         BiocStatus = factor(
             status,
             levels = .VERSION_TAGS
-        )  
+        )
     ))
 }
 

--- a/R/version.R
+++ b/R/version.R
@@ -100,8 +100,8 @@ format.version_sentinel <-
     txt
 }
 
-.version_config_section <- function(txt, tag) {
-    grps <- grep("^[^[:blank:]]", txt)
+.version_config_section <- function(txt, grp, tag) {
+    grps <- grep(grp, txt)
     start <- match(grep(tag, txt), grps)
     if (!length(start))
         return(setNames(character(), character()))
@@ -112,7 +112,7 @@ format.version_sentinel <-
 .version_map_config_element <-
     function(txt, tag)
 {
-    map <- .version_config_section(txt = txt, tag = tag)
+    map <- .version_config_section(txt = txt, grp = "^[^[:blank:]]", tag = tag)
     map <- trimws(gsub("\"", "", sub(" #.*", "", map)))
     pattern <- "(.*): (.*)"
     key <- sub(pattern, "\\1", map)

--- a/R/version.R
+++ b/R/version.R
@@ -78,11 +78,9 @@ format.version_sentinel <-
 .version_validity_online_check <-
     function()
 {
-    opt <- .env_opt_lgl(
-        "BIOCONDUCTOR_ONLINE_VERSION_DIAGNOSIS",
-        "BIOCONDUCTOR_ONLINE_VERSION_DIAGNOSIS",
-        TRUE
-    )
+    opt <- Sys.getenv("BIOCONDUCTOR_ONLINE_VERSION_DIAGNOSIS", TRUE)
+    opt <- getOption("BIOCONDUCTOR_ONLINE_VERSION_DIAGNOSIS", opt)
+    opt <- isTRUE(as.logical(opt))
 
     if (.VERSION_MAP$WARN_NO_ONLINE_CONFIG && !opt) {
         .VERSION_MAP$WARN_NO_ONLINE_CONFIG <- FALSE

--- a/R/version.R
+++ b/R/version.R
@@ -78,9 +78,11 @@ format.version_sentinel <-
 .version_validity_online_check <-
     function()
 {
-    opt <- Sys.getenv("BIOCONDUCTOR_ONLINE_VERSION_DIAGNOSIS", TRUE)
-    opt <- getOption("BIOCONDUCTOR_ONLINE_VERSION_DIAGNOSIS", opt)
-    opt <- isTRUE(as.logical(opt))
+    opt <- .env_opt_lgl(
+        "BIOCONDUCTOR_ONLINE_VERSION_DIAGNOSIS",
+        "BIOCONDUCTOR_ONLINE_VERSION_DIAGNOSIS",
+        TRUE
+    )
 
     if (.VERSION_MAP$WARN_NO_ONLINE_CONFIG && !opt) {
         .VERSION_MAP$WARN_NO_ONLINE_CONFIG <- FALSE

--- a/man/repositories.Rd
+++ b/man/repositories.Rd
@@ -4,7 +4,6 @@
 \alias{repositories}
 \alias{BiocManager.check_repositories}
 \alias{containerRepository}
-\alias{BINARY_BASE_URL}
 \title{Display current Bioconductor and CRAN repositories.}
 \usage{
 repositories(
@@ -61,8 +60,9 @@ best practice is to use packages from the same release, and from
 the appropriate CRAN repository.
 
 To install binary packages on containerized versions of Bioconductor,
-a default binary package location URL is set as a package constant,
-see \code{BiocManager:::BINARY_BASE_URL}. Binary package installations
+a default binary package location URL is resolved from the
+\code{getOption("BioC_mirror")} (or the default \verb{https://bioconductor.org})
+and the \code{BiocManager:::BINARY_SLUG_URL}. Binary package installations
 are enabled by default for Bioconductor Docker containers. Anyone
 wishing to opt out of the binary package installation can set either the
 variable or the option, \env{BIOCONDUCTOR_USE_CONTAINER_REPOSITORY}, to
@@ -96,8 +96,14 @@ as much as possible to \emph{Bioconductor} best practices, use
 \code{repositories()} as a basis for constructing the \verb{repos =} argument
 to \code{install.packages()} and related functions.
 
-The unexported URL to the base repository is available with
-\code{BiocManager:::BINARY_BASE_URL}.
+On Continuous Integration (CI) platforms, \code{BiocManager} re-routes
+requests to low-cost mirror sites. Users may opt out of this by
+setting either the option or the variable to \code{FALSE}, i.e.,
+\code{options(BiocManager.use_ci_mirror = FALSE)} or
+\env{BIOCMANAGER_USE_CI_MIRROR}.
+
+The binary URL is a combination of \code{getOption("BioC_mirror")} and
+\code{BiocManager:::BINARY_SLUG_URL}.
 
 \env{BIOCONDUCTOR_USE_CONTAINER_REPOSITORY} is an environment
 variable or global \code{options()} which, when set to \code{FALSE}, avoids

--- a/man/repositories.Rd
+++ b/man/repositories.Rd
@@ -62,7 +62,7 @@ the appropriate CRAN repository.
 To install binary packages on containerized versions of Bioconductor,
 a default binary package location URL is resolved from the
 \code{getOption("BioC_mirror")} (or the default \verb{https://bioconductor.org})
-and the \code{BiocManager:::BINARY_SLUG_URL}. Binary package installations
+and the \code{BiocManager:::.BINARY_SLUG_URL}. Binary package installations
 are enabled by default for Bioconductor Docker containers. Anyone
 wishing to opt out of the binary package installation can set either the
 variable or the option, \env{BIOCONDUCTOR_USE_CONTAINER_REPOSITORY}, to
@@ -103,7 +103,7 @@ setting either the option or the variable to \code{FALSE}, i.e.,
 \env{BIOCMANAGER_USE_CI_MIRROR}.
 
 The binary URL is a combination of \code{getOption("BioC_mirror")} and
-\code{BiocManager:::BINARY_SLUG_URL}.
+\code{BiocManager:::.BINARY_SLUG_URL}.
 
 \env{BIOCONDUCTOR_USE_CONTAINER_REPOSITORY} is an environment
 variable or global \code{options()} which, when set to \code{FALSE}, avoids

--- a/tests/testthat/test_repositories.R
+++ b/tests/testthat/test_repositories.R
@@ -177,7 +177,7 @@ test_that("config.yaml is parsed correctly", {
         "      https_mirror_url: https://foobar.com/"
     )
     expect_identical(
-        .repositories_config_mirror_element(
+        .repositories_config_mirror_url(
             test.config
         ),
         "https://foobar.com/"
@@ -189,10 +189,10 @@ test_that("config.yaml is parsed correctly", {
         "      https_mirror_url: "
     )
     expect_identical(
-        .repositories_config_mirror_element(
+        .repositories_config_mirror_url(
             test.config
         ),
-        "https://bioconductor.org"
+        .BIOC_DOMAIN_URL
     )
 })
 

--- a/tests/testthat/test_repositories.R
+++ b/tests/testthat/test_repositories.R
@@ -169,6 +169,33 @@ test_that("'.repositories_filter()' works", {
     expect_equal(.repositories_filter(repos), repos0)
 })
 
+test_that("config.yaml is parsed correctly", {
+    test.config <- c(
+        "mirrors:",
+        "  - 1-Bioconductor:",
+        "    - institution: Bioconductor CI redirect",
+        "      https_mirror_url: https://foobar.com/"
+    )
+    expect_identical(
+        .repositories_config_mirror_element(
+            test.config
+        ),
+        "https://foobar.com/"
+    )
+    test.config <- c(
+        "mirrors:",
+        "  - 1-Bioconductor:",
+        "    - institution: Bioconductor CI redirect",
+        "      https_mirror_url: "
+    )
+    expect_identical(
+        .repositories_config_mirror_element(
+            test.config
+        ),
+        "https://bioconductor.org"
+    )
+})
+
 test_that("'containerRepository' uses 'type' argument", {
     skip_if_offline()
     bin_url <- "https://bioconductor.org/packages/%s/container-binaries/%s"


### PR DESCRIPTION
Hi Martin, @mtmorgan 
Here is a draft PR to re-direct `CI=TRUE` environments to low-cost egress services via the `BioC_mirror` option. 

cc: @almahmoud @vjcitn 