### PR TITLE
update use of package_version in unit tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,4 +23,4 @@ BugReports: https://github.com/Bioconductor/BiocManager/issues
 VignetteBuilder: knitr
 License: Artistic-2.0
 Encoding: UTF-8
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/man/BiocManager-package.Rd
+++ b/man/BiocManager-package.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{BiocManager-package}
 \alias{BiocManager-package}
-\alias{_PACKAGE}
 \alias{BiocManager}
 \title{Install or update Bioconductor, CRAN, or GitHub packages}
 \description{

--- a/tests/testthat/test_version.R
+++ b/tests/testthat/test_version.R
@@ -116,8 +116,8 @@ test_that(".version_validity(...) works", {
 
     ## proper mock map should include all four BiocStatus fields
     .ver_map <- data.frame(
-        Bioc = package_version(list("3.9", "4.0", "4.1", "4.1")),
-        R = package_version(list("4.2", "4.3", "4.4", "4.5")),
+        Bioc = package_version(c("3.9", "4.0", "4.1", "4.1")),
+        R = package_version(c("4.2", "4.3", "4.4", "4.5")),
         BiocStatus = c("out-of-date", "release", "devel", "future")
     )
 
@@ -147,8 +147,8 @@ test_that(".version_bioc() works", {
     skip_if_offline()
 
     .ver_map <- data.frame(
-        Bioc = package_version(list("4.0", "4.1", "4.1")),
-        R = package_version(list("4.3", "4.4", "4.5")),
+        Bioc = package_version(c("4.0", "4.1", "4.1")),
+        R = package_version(c("4.3", "4.4", "4.5")),
         BiocStatus = c("release", "devel", "future")
     )
 
@@ -194,8 +194,8 @@ test_that(".version_R() works", {
     skip_if_offline()
 
     .ver_map <- data.frame(
-        Bioc = package_version(list("4.0", "4.1", "4.1")),
-        R = package_version(list("4.3", "4.4", "4.5")),
+        Bioc = package_version(c("4.0", "4.1", "4.1")),
+        R = package_version(c("4.3", "4.4", "4.5")),
         BiocStatus = c("release", "devel", "future")
     )
     ## out-of-date is missing


### PR DESCRIPTION
- using a list() argument fails after base R r85933 'Stop on invalid numeric version specs by default.'
- a simple character vector c("1.1", "1.2") seems backward-compatible