### PR TITLE
Get name from env variable instead of hardcoded

### DIFF
--- a/R/repositories.R
+++ b/R/repositories.R
@@ -243,7 +243,7 @@ repositories <- function(
 {
     container_version <- Sys.getenv("BIOCONDUCTOR_DOCKER_VERSION")
     if (nzchar(container_version)) {
-        platform <- Sys.getenv("BIOCONDUCTOR_NAME")
+        platform <- Sys.getenv("BIOCONDUCTOR_NAME", "bioconductor_docker")
     } else {
         platform <- Sys.getenv("TERRA_R_PLATFORM")
         container_version <- Sys.getenv("TERRA_R_PLATFORM_BINARY_VERSION")

--- a/R/repositories.R
+++ b/R/repositories.R
@@ -243,7 +243,7 @@ repositories <- function(
 {
     container_version <- Sys.getenv("BIOCONDUCTOR_DOCKER_VERSION")
     if (nzchar(container_version)) {
-        platform <- "bioconductor_docker"
+        platform <- Sys.getenv("BIOCONDUCTOR_NAME")
     } else {
         platform <- Sys.getenv("TERRA_R_PLATFORM")
         container_version <- Sys.getenv("TERRA_R_PLATFORM_BINARY_VERSION")


### PR DESCRIPTION
Friends with https://github.com/Bioconductor/bioconductor_docker/pull/116 , to start a backwards compatible path for multi-arch binaries