### PR TITLE
Fix for testthat 3.3.0

### DIFF
--- a/tests/testthat/test_install.R
+++ b/tests/testthat/test_install.R
@@ -218,11 +218,11 @@ test_that("install() passes the force argument to .install", {
     .skip_if_misconfigured()
     skip_if_offline()
     expect_true(
-        with_mock(
-            `BiocManager:::.install` = function(...) {
+        with_mocked_bindings(
+            .install = function(...) {
                 list(...)[['force']]
             },
-            `BiocManager:::.version_compare` = function(...) {
+            .version_compare = function(...) {
                 0L
             },
             suppressMessages(
@@ -231,11 +231,11 @@ test_that("install() passes the force argument to .install", {
         )
     )
     expect_false(
-        with_mock(
-            `BiocManager:::.install` = function(...) {
+        with_mocked_bindings(
+            .install = function(...) {
                 list(...)[['force']]
             },
-            `BiocManager:::.version_compare` = function(...) {
+            .version_compare = function(...) {
                 0L
             },
             suppressMessages(
@@ -244,17 +244,17 @@ test_that("install() passes the force argument to .install", {
         )
     )
     expect_true(
-        with_mock(
-            `BiocManager:::.install` = function(...) {
+        with_mocked_bindings(
+            .install = function(...) {
                 list(...)[['force']]
             },
-            `BiocManager:::.version_compare` = function(...) {
+            .version_compare = function(...) {
                 1L
             },
-            `BiocManager:::.install_n_invalid_pkgs` = function(...) {
+            .install_n_invalid_pkgs = function(...) {
                 0L
             },
-            `BiocManager:::.install_updated_version` = function(...) {
+            .install_updated_version = function(...) {
                 pkgs <<- list(...)[['force']]
             },
             suppressMessages(
@@ -263,17 +263,17 @@ test_that("install() passes the force argument to .install", {
         )
     )
     expect_false(
-        with_mock(
-            `BiocManager:::.install` = function(...) {
+        with_mocked_bindings(
+            .install = function(...) {
                 list(...)[['force']]
             },
-            `BiocManager:::.version_compare` = function(...) {
+            .version_compare = function(...) {
                 1L
             },
-            `BiocManager:::.install_n_invalid_pkgs` = function(...) {
+            .install_n_invalid_pkgs = function(...) {
                 0L
             },
-            `BiocManager:::.install_updated_version` = function(...) {
+            .install_updated_version = function(...) {
                 pkgs <<- list(...)[['force']]
             },
             suppressMessages(
@@ -282,17 +282,17 @@ test_that("install() passes the force argument to .install", {
         )
     )
     expect_false(
-        with_mock(
-            `BiocManager:::.install` = function(...) {
+        with_mocked_bindings(
+            .install = function(...) {
                 list(...)[['update']]
             },
-            `BiocManager:::.version_compare` = function(...) {
+            .version_compare = function(...) {
                 1L
             },
-            `BiocManager:::.install_n_invalid_pkgs` = function(...) {
+            .install_n_invalid_pkgs = function(...) {
                 0L
             },
-            `BiocManager:::.install_updated_version` = function(...) {
+            .install_updated_version = function(...) {
                 pkgs <<- list(...)[['update']]
             },
             suppressMessages(
@@ -301,17 +301,17 @@ test_that("install() passes the force argument to .install", {
         )
     )    
     expect_false(
-        with_mock(
-            `BiocManager:::.install` = function(...) {
+        with_mocked_bindings(
+            .install = function(...) {
                 list(...)[['ask']]
             },
-            `BiocManager:::.version_compare` = function(...) {
+            .version_compare = function(...) {
                 1L
             },
-            `BiocManager:::.install_n_invalid_pkgs` = function(...) {
+            .install_n_invalid_pkgs = function(...) {
                 0L
             },
-            `BiocManager:::.install_updated_version` = function(...) {
+            .install_updated_version = function(...) {
                 pkgs <<- list(...)[['ask']]
             },
             suppressMessages(
@@ -320,33 +320,38 @@ test_that("install() passes the force argument to .install", {
         )
     )    
     expect_null(
-        with_mock(
-            `BiocManager:::.install` = function(...) {
+        with_mocked_bindings(
+            .install = function(...) {
                 list(...)[['checkBuilt']]
             },
-            `BiocManager:::.version_compare` = function(...) {
+            .version_compare = function(...) {
                 1L
             },
-            `BiocManager:::.install_n_invalid_pkgs` = function(...) {
+            .install_n_invalid_pkgs = function(...) {
                 0L
             },
-            `BiocManager:::.install_updated_version` = function(...) {
+            .install_updated_version = function(...) {
                 pkgs <<- list(...)[['checkBuilt']]
             },
             suppressMessages(
                 install(
                     force = FALSE, checkBuilt = TRUE,
                     update = FALSE, ask = FALSE
-                )
+            )
             )
         )
     )
 })
 
 test_that("install() without package names passes ... to install.packages", {
+    skip("Doesn't work with with_mocked_bindings()")
+    # This test relied on the mocked version of install.packages() being 
+    # called from update.packages(). This no longer happens because 
+    # with_mocked_bindings() only affects the current package.
+
     .skip_if_misconfigured()
     object <- FALSE
-    with_mock(
+    with_mocked_bindings(
         available.packages = function(...) {
             cbind(
                 Package = "BiocGenerics", Version = "0.33.0",

--- a/tests/testthat/test_valid.R
+++ b/tests/testthat/test_valid.R
@@ -3,8 +3,8 @@ context("Check for the valid function")
 test_that("valid returns an empty list without internet", {
     .skip_if_misconfigured()
 
-    result <- with_mock(
-        `BiocManager:::.repositories_filter` = function(...) {
+    result <- with_mocked_bindings(
+        .repositories_filter = function(...) {
             ..1[FALSE]
         }, BiocManager::valid()
     )

--- a/tests/testthat/test_version.R
+++ b/tests/testthat/test_version.R
@@ -153,8 +153,8 @@ test_that(".version_bioc() works", {
     )
 
     ## map misconfiguration
-    with_mock(
-        `BiocManager:::.version_map` = function(...) {
+    with_mocked_bindings(
+        .version_map = function(...) {
             .ver_map
         },
         expect_match(
@@ -166,8 +166,8 @@ test_that(".version_bioc() works", {
     .ver_map <- rbind.data.frame(c("3.9", "4.2", "out-of-date"), .ver_map)
 
     ## all good
-    with_mock(
-        `BiocManager:::.version_map` = function(...) {
+    with_mocked_bindings(
+        .version_map = function(...) {
             .ver_map
         },
         expect_identical(
@@ -178,8 +178,8 @@ test_that(".version_bioc() works", {
     ## type misspecified
     type_miss <-
         "Bioconductor version cannot be validated; is type input misspecified?.*"
-    with_mock(
-        `BiocManager:::.version_map` = function(...) {
+    with_mocked_bindings(
+        .version_map = function(...) {
             .ver_map
         },
         expect_match(
@@ -199,8 +199,8 @@ test_that(".version_R() works", {
         BiocStatus = c("release", "devel", "future")
     )
     ## out-of-date is missing
-    with_mock(
-        `BiocManager:::.version_map` = function(...) {
+    with_mocked_bindings(
+        .version_map = function(...) {
             .ver_map
         },
         expect_match(
@@ -210,8 +210,8 @@ test_that(".version_R() works", {
     )
     .ver_map <- rbind.data.frame(c("3.9", "4.2", "out-of-date"), .ver_map)
     ## all good
-    with_mock(
-        `BiocManager:::.version_map` = function(...) {
+    with_mocked_bindings(
+        .version_map = function(...) {
             .ver_map
         },
         expect_identical(
@@ -219,8 +219,8 @@ test_that(".version_R() works", {
         )
     )
     ## type is misspecified
-    with_mock(
-        `BiocManager:::.version_map` = function(...) {
+    with_mocked_bindings(
+        .version_map = function(...) {
             .ver_map
         },
         expect_match(
@@ -362,8 +362,8 @@ test_that(".version_sentinel() works", {
 })
 
 test_that(".version_BiocVersion returns .version_sentinel output", {
-    with_mock(
-        `BiocManager:::.version_BiocVersion_installed` = function(...) {
+    with_mocked_bindings(
+        .version_BiocVersion_installed = function(...) {
             FALSE
         },
         expect_identical(
@@ -374,8 +374,8 @@ test_that(".version_BiocVersion returns .version_sentinel output", {
 })
 
 test_that(".version_map_get_offline() works", {
-    with_mock(
-        `BiocManager:::.version_BiocVersion` = function(...) {
+    with_mocked_bindings(
+        .version_BiocVersion = function(...) {
             .version_sentinel("BiocVersion is not installed")
         },
         expect_identical(
@@ -387,11 +387,11 @@ test_that(".version_map_get_offline() works", {
     skip_if_offline()
     rver <- package_version("4.3")
     class(rver) <- c("R_system_version", class(rver))
-    with_mock(
-        `BiocManager:::.version_BiocVersion` = function(...) {
+    with_mocked_bindings(
+        .version_BiocVersion = function(...) {
             package_version("3.14")
         },
-        `BiocManager:::.version_R_version` = function(...) {
+        .version_R_version = function(...) {
             rver <- package_version("4.3")
             class(rver) <- c("R_system_version", class(rver))
             rver
@@ -410,11 +410,11 @@ test_that("version chooses best", {
     target_version <-  structure(
         list(c(3L, 17L), class = c("package_version", "numeric_version"))
     )
-    with_mock(
-        `BiocManager:::.version_BiocVersion` = function(...) {
+    with_mocked_bindings(
+        .version_BiocVersion = function(...) {
             .version_sentinel("BiocVersion is not installed")
         },
-        `BiocManager:::.version_choose_best` = function(...) {
+        .version_choose_best = function(...) {
             target_version
         },
         expect_identical(


### PR DESCRIPTION
I somehow missed BiocManager in my earlier rounds of testing but this PR should get you working with latest testthat.